### PR TITLE
kt consume: stricter parsing of offsets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,5 @@ require (
 	golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4
 	golang.org/x/sys v0.0.0-20181005133103-4497e2df6f9e // indirect
 )
+
+go 1.12


### PR DESCRIPTION
Currently parseOffsets uses a regexp-based parser which is considerably
more permissive than it probably should be. It will parse almost
any string without error, even such "obviously wrong" specifications
such as `bogus` and `::::`.

We specify the grammar somewhat more formally and rewrite
the parser so that it's not regexp-based, which allows us to give
better error messages, is arguably more understandable and will
catch user errors before we actually try to talk to Kafka.

This change is a prelude to a change that is intended to add timestamp-based
search to kt. By using a more precise grammar specification, that change
should become easier.

We also add some missing `TestParseOffsets` test cases to cover errors
and some other corners of the grammar.