### PR TITLE
understand time-based positions in parseOffsets

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -103,7 +103,7 @@ func (a0 anchor) eq(a1 anchor) bool {
 
 // anchorDiff represents an offset from an anchor position.
 type anchorDiff struct {
-	// diffIsTime specifies which diff field is valid.
+	// isDuration specifies which diff field is valid.
 	// If it's true, the difference is specified as a duration
 	// in the duration field; otherwise it's specified as
 	// an offset in offset.

--- a/consume_test.go
+++ b/consume_test.go
@@ -24,8 +24,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: sarama.OffsetOldest},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(sarama.OffsetOldest),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -34,8 +34,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    ",",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: sarama.OffsetOldest},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(sarama.OffsetOldest),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -44,8 +44,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "all",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: sarama.OffsetOldest},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(sarama.OffsetOldest),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -54,8 +54,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "oldest",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: sarama.OffsetOldest},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(sarama.OffsetOldest),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -64,8 +64,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "resume",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: offsetResume},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(offsetResume),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -74,8 +74,8 @@ func TestParseOffsets(t *testing.T) {
 			input: "	all ",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: sarama.OffsetOldest},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(sarama.OffsetOldest),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -84,8 +84,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "all=+0:",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: sarama.OffsetOldest},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(sarama.OffsetOldest),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -94,16 +94,16 @@ func TestParseOffsets(t *testing.T) {
 			input:    "1,2,4",
 			expected: map[int32]interval{
 				1: interval{
-					start: position{startOffset: sarama.OffsetOldest},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(sarama.OffsetOldest),
+					end:   positionAtOffset(maxOffset),
 				},
 				2: interval{
-					start: position{startOffset: sarama.OffsetOldest},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(sarama.OffsetOldest),
+					end:   positionAtOffset(maxOffset),
 				},
 				4: interval{
-					start: position{startOffset: sarama.OffsetOldest},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(sarama.OffsetOldest),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -112,8 +112,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=",
 			expected: map[int32]interval{
 				0: interval{
-					start: position{startOffset: sarama.OffsetOldest},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(sarama.OffsetOldest),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -122,8 +122,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=1",
 			expected: map[int32]interval{
 				0: interval{
-					start: position{startOffset: 1},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(1),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -132,8 +132,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=1:",
 			expected: map[int32]interval{
 				0: interval{
-					start: position{startOffset: 1},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(1),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -142,16 +142,16 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=4:,2=1:10,6",
 			expected: map[int32]interval{
 				0: interval{
-					start: position{startOffset: 4},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(4),
+					end:   positionAtOffset(maxOffset),
 				},
 				2: interval{
-					start: position{startOffset: 1},
-					end:   position{startOffset: 10},
+					start: positionAtOffset(1),
+					end:   positionAtOffset(10),
 				},
 				6: interval{
-					start: position{startOffset: sarama.OffsetOldest},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(sarama.OffsetOldest),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -160,8 +160,11 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=-1",
 			expected: map[int32]interval{
 				0: interval{
-					start: position{startOffset: sarama.OffsetNewest, diffOffset: -1},
-					end:   position{startOffset: maxOffset},
+					start: position{
+						anchor: anchorAtOffset(sarama.OffsetNewest),
+						diff:   anchorDiff{offset: -1},
+					},
+					end: positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -170,8 +173,11 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=-1:",
 			expected: map[int32]interval{
 				0: interval{
-					start: position{startOffset: sarama.OffsetNewest, diffOffset: -1},
-					end:   position{startOffset: maxOffset},
+					start: position{
+						anchor: anchorAtOffset(sarama.OffsetNewest),
+						diff:   anchorDiff{offset: -1},
+					},
+					end: positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -180,8 +186,11 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=resume-10",
 			expected: map[int32]interval{
 				0: interval{
-					start: position{startOffset: offsetResume, diffOffset: -10},
-					end:   position{startOffset: maxOffset},
+					start: position{
+						anchor: anchorAtOffset(offsetResume),
+						diff:   anchorDiff{offset: -10},
+					},
+					end: positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -190,8 +199,11 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=+1",
 			expected: map[int32]interval{
 				0: interval{
-					start: position{startOffset: sarama.OffsetOldest, diffOffset: 1},
-					end:   position{startOffset: maxOffset},
+					start: position{
+						anchor: anchorAtOffset(sarama.OffsetOldest),
+						diff:   anchorDiff{offset: 1},
+					},
+					end: positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -200,8 +212,11 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=+1:",
 			expected: map[int32]interval{
 				0: interval{
-					start: position{startOffset: sarama.OffsetOldest, diffOffset: 1},
-					end:   position{startOffset: maxOffset},
+					start: position{
+						anchor: anchorAtOffset(sarama.OffsetOldest),
+						diff:   anchorDiff{offset: 1},
+					},
+					end: positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -210,8 +225,14 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=+1:-1",
 			expected: map[int32]interval{
 				0: interval{
-					start: position{startOffset: sarama.OffsetOldest, diffOffset: 1},
-					end:   position{startOffset: sarama.OffsetNewest, diffOffset: -1},
+					start: position{
+						anchor: anchorAtOffset(sarama.OffsetOldest),
+						diff:   anchorDiff{offset: 1},
+					},
+					end: position{
+						anchor: anchorAtOffset(sarama.OffsetNewest),
+						diff:   anchorDiff{offset: -1},
+					},
 				},
 			},
 		},
@@ -220,12 +241,18 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=+1:-1,all=1:10",
 			expected: map[int32]interval{
 				0: interval{
-					start: position{startOffset: sarama.OffsetOldest, diffOffset: 1},
-					end:   position{startOffset: sarama.OffsetNewest, diffOffset: -1},
+					start: position{
+						anchor: anchorAtOffset(sarama.OffsetOldest),
+						diff:   anchorDiff{offset: 1},
+					},
+					end: position{
+						anchor: anchorAtOffset(sarama.OffsetNewest),
+						diff:   anchorDiff{offset: -1},
+					},
 				},
 				-1: interval{
-					start: position{startOffset: 1, diffOffset: 0},
-					end:   position{startOffset: 10, diffOffset: 0},
+					start: positionAtOffset(1),
+					end:   positionAtOffset(10),
 				},
 			},
 		},
@@ -234,8 +261,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=oldest:newest",
 			expected: map[int32]interval{
 				0: interval{
-					start: position{startOffset: sarama.OffsetOldest, diffOffset: 0},
-					end:   position{startOffset: sarama.OffsetNewest, diffOffset: 0},
+					start: positionAtOffset(sarama.OffsetOldest),
+					end:   positionAtOffset(sarama.OffsetNewest),
 				},
 			},
 		},
@@ -244,8 +271,14 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=oldest+10:newest-10",
 			expected: map[int32]interval{
 				0: interval{
-					start: position{startOffset: sarama.OffsetOldest, diffOffset: 10},
-					end:   position{startOffset: sarama.OffsetNewest, diffOffset: -10},
+					start: position{
+						anchor: anchorAtOffset(sarama.OffsetOldest),
+						diff:   anchorDiff{offset: 10},
+					},
+					end: position{
+						anchor: anchorAtOffset(sarama.OffsetNewest),
+						diff:   anchorDiff{offset: -10},
+					},
 				},
 			},
 		},
@@ -254,8 +287,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "newest",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: sarama.OffsetNewest, diffOffset: 0},
-					end:   position{startOffset: maxOffset, diffOffset: 0},
+					start: positionAtOffset(sarama.OffsetNewest),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -264,8 +297,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "10",
 			expected: map[int32]interval{
 				10: interval{
-					start: position{startOffset: sarama.OffsetOldest, diffOffset: 0},
-					end:   position{startOffset: maxOffset, diffOffset: 0},
+					start: positionAtOffset(sarama.OffsetOldest),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -274,8 +307,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "10:20",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: 10},
-					end:   position{startOffset: 20},
+					start: positionAtOffset(10),
+					end:   positionAtOffset(20),
 				},
 			},
 		},
@@ -284,8 +317,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "10:",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: 10},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(10),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -294,8 +327,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "all=newest:",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: sarama.OffsetNewest, diffOffset: 0},
-					end:   position{startOffset: maxOffset, diffOffset: 0},
+					start: positionAtOffset(sarama.OffsetNewest),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -304,8 +337,11 @@ func TestParseOffsets(t *testing.T) {
 			input:    "newest-10:",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: sarama.OffsetNewest, diffOffset: -10},
-					end:   position{startOffset: maxOffset, diffOffset: 0},
+					start: position{
+						anchor: anchorAtOffset(sarama.OffsetNewest),
+						diff:   anchorDiff{offset: -10},
+					},
+					end: positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -314,8 +350,11 @@ func TestParseOffsets(t *testing.T) {
 			input:    "oldest+10:",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: sarama.OffsetOldest, diffOffset: 10},
-					end:   position{startOffset: maxOffset, diffOffset: 0},
+					start: position{
+						anchor: anchorAtOffset(sarama.OffsetOldest),
+						diff:   anchorDiff{offset: 10},
+					},
+					end: positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -324,8 +363,11 @@ func TestParseOffsets(t *testing.T) {
 			input:    "-10:",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: sarama.OffsetNewest, diffOffset: -10},
-					end:   position{startOffset: maxOffset, diffOffset: 0},
+					start: position{
+						anchor: anchorAtOffset(sarama.OffsetNewest),
+						diff:   anchorDiff{offset: -10},
+					},
+					end: positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -334,8 +376,11 @@ func TestParseOffsets(t *testing.T) {
 			input:    "+10:",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: sarama.OffsetOldest, diffOffset: 10},
-					end:   position{startOffset: maxOffset, diffOffset: 0},
+					start: position{
+						anchor: anchorAtOffset(sarama.OffsetOldest),
+						diff:   anchorDiff{offset: 10},
+					},
+					end: positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -344,8 +389,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "1000+3",
 			expected: map[int32]interval{
 				-1: interval{
-					start: position{startOffset: 1003},
-					end:   position{startOffset: maxOffset},
+					start: positionAtOffset(1003),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -399,16 +444,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "[2019-08-31T13:06:08.234Z]",
 			expected: map[int32]interval{
 				-1: {
-					start: position{
-						startIsTime: true,
-						startTime: timeRange{
-							t0: T("2019-08-31T13:06:08.234Z"),
-							t1: T("2019-08-31T13:06:08.234Z"),
-						},
-					},
-					end: position{
-						startOffset: maxOffset,
-					},
+					start: positionAtTime(T("2019-08-31T13:06:08.234Z")),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -417,16 +454,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "[2019-08-31T13:06:08.234-04:00]",
 			expected: map[int32]interval{
 				-1: {
-					start: position{
-						startIsTime: true,
-						startTime: timeRange{
-							t0: T("2019-08-31T17:06:08.234Z"),
-							t1: T("2019-08-31T17:06:08.234Z"),
-						},
-					},
-					end: position{
-						startOffset: maxOffset,
-					},
+					start: positionAtTime(T("2019-08-31T17:06:08.234Z")),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -435,16 +464,28 @@ func TestParseOffsets(t *testing.T) {
 			input:    "[2019-08-31]",
 			expected: map[int32]interval{
 				-1: {
-					start: position{
-						startIsTime: true,
-						startTime: timeRange{
-							t0: T("2019-08-31T00:00:00Z"),
-							t1: T("2019-09-01T00:00:00Z"),
-						},
-					},
-					end: position{
-						startOffset: maxOffset,
-					},
+					start: positionAtTime(T("2019-08-31T00:00:00Z")),
+					end:   positionAtTime(T("2019-09-01T00:00:00Z")),
+				},
+			},
+		},
+		{
+			testName: "time-anchor-imprecise-explicit-colon",
+			input:    "[2019-08-31]:",
+			expected: map[int32]interval{
+				-1: {
+					start: positionAtTime(T("2019-08-31T00:00:00Z")),
+					end:   positionAtOffset(maxOffset),
+				},
+			},
+		},
+		{
+			testName: "time-anchor-date-explicit-end",
+			input:    "[2019-08-31]:[2019-09-04]",
+			expected: map[int32]interval{
+				-1: {
+					start: positionAtTime(T("2019-08-31T00:00:00Z")),
+					end:   positionAtTime(T("2019-09-05T00:00:00Z")),
 				},
 			},
 		},
@@ -453,16 +494,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "[2019-08]",
 			expected: map[int32]interval{
 				-1: {
-					start: position{
-						startIsTime: true,
-						startTime: timeRange{
-							t0: T("2019-08-01T00:00:00Z"),
-							t1: T("2019-09-01T00:00:00Z"),
-						},
-					},
-					end: position{
-						startOffset: maxOffset,
-					},
+					start: positionAtTime(T("2019-08-01T00:00:00Z")),
+					end:   positionAtTime(T("2019-09-01T00:00:00Z")),
 				},
 			},
 		},
@@ -471,16 +504,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "[2019]",
 			expected: map[int32]interval{
 				-1: {
-					start: position{
-						startIsTime: true,
-						startTime: timeRange{
-							t0: T("2019-01-01T00:00:00Z"),
-							t1: T("2020-01-01T00:00:00Z"),
-						},
-					},
-					end: position{
-						startOffset: maxOffset,
-					},
+					start: positionAtTime(T("2019-01-01T00:00:00Z")),
+					end:   positionAtTime(T("2020-01-01T00:00:00Z")),
 				},
 			},
 		},
@@ -489,16 +514,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "[13:45]",
 			expected: map[int32]interval{
 				-1: {
-					start: position{
-						startIsTime: true,
-						startTime: timeRange{
-							t0: T("2011-02-03T13:45:00Z"),
-							t1: T("2011-02-03T13:46:00Z"),
-						},
-					},
-					end: position{
-						startOffset: maxOffset,
-					},
+					start: positionAtTime(T("2011-02-03T13:45:00Z")),
+					end:   positionAtTime(T("2011-02-03T13:46:00Z")),
 				},
 			},
 		},
@@ -507,16 +524,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "[13:45:12.345]",
 			expected: map[int32]interval{
 				-1: {
-					start: position{
-						startIsTime: true,
-						startTime: timeRange{
-							t0: T("2011-02-03T13:45:12.345Z"),
-							t1: T("2011-02-03T13:45:12.345Z"),
-						},
-					},
-					end: position{
-						startOffset: maxOffset,
-					},
+					start: positionAtTime(T("2011-02-03T13:45:12.345Z")),
+					end:   positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -525,16 +534,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "[4pm]",
 			expected: map[int32]interval{
 				-1: {
-					start: position{
-						startIsTime: true,
-						startTime: timeRange{
-							t0: T("2011-02-03T16:00:00Z"),
-							t1: T("2011-02-03T17:00:00Z"),
-						},
-					},
-					end: position{
-						startOffset: maxOffset,
-					},
+					start: positionAtTime(T("2011-02-03T16:00:00Z")),
+					end:   positionAtTime(T("2011-02-03T17:00:00Z")),
 				},
 			},
 		},
@@ -543,20 +544,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "[2019-08-31T13:06:08.234Z]:[2023-02-05T12:01:02.6789Z]",
 			expected: map[int32]interval{
 				-1: {
-					start: position{
-						startIsTime: true,
-						startTime: timeRange{
-							t0: T("2019-08-31T13:06:08.234Z"),
-							t1: T("2019-08-31T13:06:08.234Z"),
-						},
-					},
-					end: position{
-						startIsTime: true,
-						startTime: timeRange{
-							t0: T("2023-02-05T12:01:02.6789Z"),
-							t1: T("2023-02-05T12:01:02.6789Z"),
-						},
-					},
+					start: positionAtTime(T("2019-08-31T13:06:08.234Z")),
+					end:   positionAtTime(T("2023-02-05T12:01:02.6789Z")),
 				},
 			},
 		},
@@ -566,15 +555,12 @@ func TestParseOffsets(t *testing.T) {
 			expected: map[int32]interval{
 				-1: {
 					start: position{
-						startIsTime: true,
-						startTime: timeRange{
-							t0: T("2011-02-03T16:00:00Z"),
-							t1: T("2011-02-03T17:00:00Z"),
-						},
-						diffOffset: -123,
+						anchor: anchorAtTime(T("2011-02-03T16:00:00Z")),
+						diff:   anchorDiff{offset: -123},
 					},
 					end: position{
-						startOffset: maxOffset,
+						anchor: anchorAtTime(T("2011-02-03T17:00:00Z")),
+						diff:   anchorDiff{offset: -123},
 					},
 				},
 			},
@@ -585,13 +571,13 @@ func TestParseOffsets(t *testing.T) {
 			expected: map[int32]interval{
 				-1: {
 					start: position{
-						startOffset: 1234,
-						diffIsTime:  true,
-						diffTime:    -(time.Hour + 3*time.Second),
+						anchor: anchorAtOffset(1234),
+						diff: anchorDiff{
+							isDuration: true,
+							duration:   -(time.Hour + 3*time.Second),
+						},
 					},
-					end: position{
-						startOffset: maxOffset,
-					},
+					end: positionAtOffset(maxOffset),
 				},
 			},
 		},
@@ -601,31 +587,23 @@ func TestParseOffsets(t *testing.T) {
 			expected: map[int32]interval{
 				-1: {
 					start: position{
-						startOffset: 1234,
-						diffIsTime:  true,
-						diffTime:    555 * time.Millisecond,
+						anchor: anchorAtOffset(1234),
+						diff: anchorDiff{
+							isDuration: true,
+							duration:   555 * time.Millisecond,
+						},
 					},
-					end: position{
-						startOffset: maxOffset,
-					},
+					end: positionAtOffset(maxOffset),
 				},
 			},
 		},
 		{
-			testName: "time-anchor-combines-with-time-rel",
+			testName: "time-anchor-combined-with-time-rel",
 			input:    "[3pm]+5s",
 			expected: map[int32]interval{
 				-1: {
-					start: position{
-						startIsTime: true,
-						startTime: timeRange{
-							t0: T("2011-02-03T15:00:05Z"),
-							t1: T("2011-02-03T16:00:05Z"),
-						},
-					},
-					end: position{
-						startOffset: maxOffset,
-					},
+					start: positionAtTime(T("2011-02-03T15:00:05Z")),
+					end:   positionAtTime(T("2011-02-03T16:00:05Z")),
 				},
 			},
 		},
@@ -660,8 +638,8 @@ func TestFindPartitionsToConsume(t *testing.T) {
 			topic: "a",
 			offsets: map[int32]interval{
 				10: {
-					start: position{startOffset: 2},
-					end:   position{startOffset: 4},
+					start: positionAtOffset(2),
+					end:   positionAtOffset(4),
 				},
 			},
 			consumer: tConsumer{
@@ -679,8 +657,8 @@ func TestFindPartitionsToConsume(t *testing.T) {
 			topic: "a",
 			offsets: map[int32]interval{
 				-1: {
-					start: position{startOffset: 3},
-					end:   position{startOffset: 41},
+					start: positionAtOffset(3),
+					end:   positionAtOffset(41),
 				},
 			},
 			consumer: tConsumer{
@@ -737,7 +715,7 @@ func TestConsume(t *testing.T) {
 	target.topic = "hans"
 	target.brokers = []string{"localhost:9092"}
 	target.offsets = map[int32]interval{
-		-1: interval{start: position{startOffset: 1}, end: position{startOffset: 5}},
+		-1: interval{start: positionAtOffset(1), end: positionAtOffset(5)},
 	}
 
 	go target.consume(partitions)
@@ -908,4 +886,21 @@ func T(s string) time.Time {
 
 // deepEquals allows comparison of the unexported fields inside the
 // value returned by parseOffsets.
-var deepEquals = qt.CmpEquals(cmp.AllowUnexported(position{}, interval{}, timeRange{}))
+var deepEquals = qt.CmpEquals(cmp.AllowUnexported(
+	interval{},
+	position{},
+	anchor{},
+	anchorDiff{},
+))
+
+func positionAtOffset(off int64) position {
+	return position{
+		anchor: anchorAtOffset(off),
+	}
+}
+
+func positionAtTime(t time.Time) position {
+	return position{
+		anchor: anchorAtTime(t),
+	}
+}

--- a/consume_test.go
+++ b/consume_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	qt "github.com/frankban/quicktest"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseOffsets(t *testing.T) {
@@ -22,8 +24,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "",
 			expected: map[int32]interval{
 				-1: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{start: 1<<63 - 1},
+					start: position{startOffset: sarama.OffsetOldest},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -32,8 +34,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    ",",
 			expected: map[int32]interval{
 				-1: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{start: 1<<63 - 1},
+					start: position{startOffset: sarama.OffsetOldest},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -42,8 +44,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "all",
 			expected: map[int32]interval{
 				-1: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: sarama.OffsetOldest},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -52,8 +54,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "oldest",
 			expected: map[int32]interval{
 				-1: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: sarama.OffsetOldest},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -62,8 +64,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "resume",
 			expected: map[int32]interval{
 				-1: interval{
-					start: offset{relative: true, start: offsetResume},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: offsetResume},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -72,8 +74,8 @@ func TestParseOffsets(t *testing.T) {
 			input: "	all ",
 			expected: map[int32]interval{
 				-1: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: sarama.OffsetOldest},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -82,8 +84,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "all=+0:",
 			expected: map[int32]interval{
 				-1: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 0},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: sarama.OffsetOldest},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -92,16 +94,16 @@ func TestParseOffsets(t *testing.T) {
 			input:    "1,2,4",
 			expected: map[int32]interval{
 				1: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: sarama.OffsetOldest},
+					end:   position{startOffset: maxOffset},
 				},
 				2: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: sarama.OffsetOldest},
+					end:   position{startOffset: maxOffset},
 				},
 				4: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: sarama.OffsetOldest},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -110,8 +112,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=",
 			expected: map[int32]interval{
 				0: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: sarama.OffsetOldest},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -120,8 +122,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=1",
 			expected: map[int32]interval{
 				0: interval{
-					start: offset{relative: false, start: 1},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: 1},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -130,8 +132,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=1:",
 			expected: map[int32]interval{
 				0: interval{
-					start: offset{relative: false, start: 1},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: 1},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -140,16 +142,16 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=4:,2=1:10,6",
 			expected: map[int32]interval{
 				0: interval{
-					start: offset{relative: false, start: 4},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: 4},
+					end:   position{startOffset: maxOffset},
 				},
 				2: interval{
-					start: offset{relative: false, start: 1},
-					end:   offset{relative: false, start: 10},
+					start: position{startOffset: 1},
+					end:   position{startOffset: 10},
 				},
 				6: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: sarama.OffsetOldest},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -158,8 +160,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=-1",
 			expected: map[int32]interval{
 				0: interval{
-					start: offset{relative: true, start: sarama.OffsetNewest, diff: -1},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: sarama.OffsetNewest, diffOffset: -1},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -168,8 +170,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=-1:",
 			expected: map[int32]interval{
 				0: interval{
-					start: offset{relative: true, start: sarama.OffsetNewest, diff: -1},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: sarama.OffsetNewest, diffOffset: -1},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -178,8 +180,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=resume-10",
 			expected: map[int32]interval{
 				0: interval{
-					start: offset{relative: true, start: offsetResume, diff: -10},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: offsetResume, diffOffset: -10},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -188,8 +190,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=+1",
 			expected: map[int32]interval{
 				0: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 1},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: sarama.OffsetOldest, diffOffset: 1},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -198,8 +200,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=+1:",
 			expected: map[int32]interval{
 				0: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 1},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: position{startOffset: sarama.OffsetOldest, diffOffset: 1},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -208,8 +210,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=+1:-1",
 			expected: map[int32]interval{
 				0: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 1},
-					end:   offset{relative: true, start: sarama.OffsetNewest, diff: -1},
+					start: position{startOffset: sarama.OffsetOldest, diffOffset: 1},
+					end:   position{startOffset: sarama.OffsetNewest, diffOffset: -1},
 				},
 			},
 		},
@@ -218,12 +220,12 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=+1:-1,all=1:10",
 			expected: map[int32]interval{
 				0: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 1},
-					end:   offset{relative: true, start: sarama.OffsetNewest, diff: -1},
+					start: position{startOffset: sarama.OffsetOldest, diffOffset: 1},
+					end:   position{startOffset: sarama.OffsetNewest, diffOffset: -1},
 				},
 				-1: interval{
-					start: offset{relative: false, start: 1, diff: 0},
-					end:   offset{relative: false, start: 10, diff: 0},
+					start: position{startOffset: 1, diffOffset: 0},
+					end:   position{startOffset: 10, diffOffset: 0},
 				},
 			},
 		},
@@ -232,8 +234,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=oldest:newest",
 			expected: map[int32]interval{
 				0: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 0},
-					end:   offset{relative: true, start: sarama.OffsetNewest, diff: 0},
+					start: position{startOffset: sarama.OffsetOldest, diffOffset: 0},
+					end:   position{startOffset: sarama.OffsetNewest, diffOffset: 0},
 				},
 			},
 		},
@@ -242,8 +244,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=oldest+10:newest-10",
 			expected: map[int32]interval{
 				0: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 10},
-					end:   offset{relative: true, start: sarama.OffsetNewest, diff: -10},
+					start: position{startOffset: sarama.OffsetOldest, diffOffset: 10},
+					end:   position{startOffset: sarama.OffsetNewest, diffOffset: -10},
 				},
 			},
 		},
@@ -252,8 +254,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "newest",
 			expected: map[int32]interval{
 				-1: interval{
-					start: offset{relative: true, start: sarama.OffsetNewest, diff: 0},
-					end:   offset{relative: false, start: 1<<63 - 1, diff: 0},
+					start: position{startOffset: sarama.OffsetNewest, diffOffset: 0},
+					end:   position{startOffset: maxOffset, diffOffset: 0},
 				},
 			},
 		},
@@ -262,8 +264,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "10",
 			expected: map[int32]interval{
 				10: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 0},
-					end:   offset{relative: false, start: 1<<63 - 1, diff: 0},
+					start: position{startOffset: sarama.OffsetOldest, diffOffset: 0},
+					end:   position{startOffset: maxOffset, diffOffset: 0},
 				},
 			},
 		},
@@ -272,8 +274,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "10:20",
 			expected: map[int32]interval{
 				-1: interval{
-					start: offset{start: 10},
-					end:   offset{start: 20},
+					start: position{startOffset: 10},
+					end:   position{startOffset: 20},
 				},
 			},
 		},
@@ -282,8 +284,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "10:",
 			expected: map[int32]interval{
 				-1: interval{
-					start: offset{start: 10},
-					end:   offset{start: 1<<63 - 1},
+					start: position{startOffset: 10},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
@@ -292,8 +294,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "all=newest:",
 			expected: map[int32]interval{
 				-1: interval{
-					start: offset{relative: true, start: sarama.OffsetNewest, diff: 0},
-					end:   offset{relative: false, start: 1<<63 - 1, diff: 0},
+					start: position{startOffset: sarama.OffsetNewest, diffOffset: 0},
+					end:   position{startOffset: maxOffset, diffOffset: 0},
 				},
 			},
 		},
@@ -302,8 +304,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "newest-10:",
 			expected: map[int32]interval{
 				-1: interval{
-					start: offset{relative: true, start: sarama.OffsetNewest, diff: -10},
-					end:   offset{relative: false, start: 1<<63 - 1, diff: 0},
+					start: position{startOffset: sarama.OffsetNewest, diffOffset: -10},
+					end:   position{startOffset: maxOffset, diffOffset: 0},
 				},
 			},
 		},
@@ -312,8 +314,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "oldest+10:",
 			expected: map[int32]interval{
 				-1: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 10},
-					end:   offset{relative: false, start: 1<<63 - 1, diff: 0},
+					start: position{startOffset: sarama.OffsetOldest, diffOffset: 10},
+					end:   position{startOffset: maxOffset, diffOffset: 0},
 				},
 			},
 		},
@@ -322,8 +324,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "-10:",
 			expected: map[int32]interval{
 				-1: interval{
-					start: offset{relative: true, start: sarama.OffsetNewest, diff: -10},
-					end:   offset{relative: false, start: 1<<63 - 1, diff: 0},
+					start: position{startOffset: sarama.OffsetNewest, diffOffset: -10},
+					end:   position{startOffset: maxOffset, diffOffset: 0},
 				},
 			},
 		},
@@ -332,84 +334,317 @@ func TestParseOffsets(t *testing.T) {
 			input:    "+10:",
 			expected: map[int32]interval{
 				-1: interval{
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 10},
-					end:   offset{relative: false, start: 1<<63 - 1, diff: 0},
+					start: position{startOffset: sarama.OffsetOldest, diffOffset: 10},
+					end:   position{startOffset: maxOffset, diffOffset: 0},
+				},
+			},
+		},
+		{
+			testName: "start-offset-combines-with-diff-offset",
+			input:    "1000+3",
+			expected: map[int32]interval{
+				-1: interval{
+					start: position{startOffset: 1003},
+					end:   position{startOffset: maxOffset},
 				},
 			},
 		},
 		{
 			testName:    "invalid-partition",
 			input:       "bogus",
-			expectedErr: `invalid offset "bogus"`,
+			expectedErr: `invalid anchor position "bogus"`,
 		},
 		{
 			testName:    "several-colons",
 			input:       ":::",
-			expectedErr: `invalid offset "::"`,
+			expectedErr: `invalid position ":::"`,
 		},
 		{
 			testName:    "bad-relative-offset-start",
 			input:       "foo+20",
-			expectedErr: `invalid offset "foo+20"`,
+			expectedErr: `invalid anchor position "foo"`,
 		},
 		{
 			testName:    "bad-relative-offset-diff",
 			input:       "oldest+bad",
-			expectedErr: `invalid offset "oldest+bad"`,
+			expectedErr: `invalid relative position "\+bad"`,
 		},
 		{
 			testName:    "bad-relative-offset-diff-at-start",
 			input:       "+bad",
-			expectedErr: `invalid offset "+bad"`,
+			expectedErr: `invalid relative position "\+bad"`,
 		},
 		{
 			testName:    "relative-offset-too-big",
 			input:       "+9223372036854775808",
-			expectedErr: `offset "+9223372036854775808" is too large`,
+			expectedErr: `offset "\+9223372036854775808" is too large`,
 		},
 		{
 			testName:    "starting-offset-too-big",
 			input:       "9223372036854775808:newest",
-			expectedErr: `offset "9223372036854775808" is too large`,
+			expectedErr: `anchor offset "9223372036854775808" is too large`,
 		},
 		{
 			testName:    "ending-offset-too-big",
 			input:       "oldest:9223372036854775808",
-			expectedErr: `offset "9223372036854775808" is too large`,
+			expectedErr: `anchor offset "9223372036854775808" is too large`,
 		},
 		{
 			testName:    "partition-too-big",
 			input:       "2147483648=oldest",
 			expectedErr: `partition number "2147483648" is too large`,
 		},
+		{
+			testName: "time-anchor-rfc3339",
+			input:    "[2019-08-31T13:06:08.234Z]",
+			expected: map[int32]interval{
+				-1: {
+					start: position{
+						startIsTime: true,
+						startTime: timeRange{
+							t0: T("2019-08-31T13:06:08.234Z"),
+							t1: T("2019-08-31T13:06:08.234Z"),
+						},
+					},
+					end: position{
+						startOffset: maxOffset,
+					},
+				},
+			},
+		},
+		{
+			testName: "time-anchor-rfc3339-not-utc",
+			input:    "[2019-08-31T13:06:08.234-04:00]",
+			expected: map[int32]interval{
+				-1: {
+					start: position{
+						startIsTime: true,
+						startTime: timeRange{
+							t0: T("2019-08-31T17:06:08.234Z"),
+							t1: T("2019-08-31T17:06:08.234Z"),
+						},
+					},
+					end: position{
+						startOffset: maxOffset,
+					},
+				},
+			},
+		},
+		{
+			testName: "time-anchor-date",
+			input:    "[2019-08-31]",
+			expected: map[int32]interval{
+				-1: {
+					start: position{
+						startIsTime: true,
+						startTime: timeRange{
+							t0: T("2019-08-31T00:00:00Z"),
+							t1: T("2019-09-01T00:00:00Z"),
+						},
+					},
+					end: position{
+						startOffset: maxOffset,
+					},
+				},
+			},
+		},
+		{
+			testName: "time-anchor-month",
+			input:    "[2019-08]",
+			expected: map[int32]interval{
+				-1: {
+					start: position{
+						startIsTime: true,
+						startTime: timeRange{
+							t0: T("2019-08-01T00:00:00Z"),
+							t1: T("2019-09-01T00:00:00Z"),
+						},
+					},
+					end: position{
+						startOffset: maxOffset,
+					},
+				},
+			},
+		},
+		{
+			testName: "time-anchor-year",
+			input:    "[2019]",
+			expected: map[int32]interval{
+				-1: {
+					start: position{
+						startIsTime: true,
+						startTime: timeRange{
+							t0: T("2019-01-01T00:00:00Z"),
+							t1: T("2020-01-01T00:00:00Z"),
+						},
+					},
+					end: position{
+						startOffset: maxOffset,
+					},
+				},
+			},
+		},
+		{
+			testName: "time-anchor-minute",
+			input:    "[13:45]",
+			expected: map[int32]interval{
+				-1: {
+					start: position{
+						startIsTime: true,
+						startTime: timeRange{
+							t0: T("2011-02-03T13:45:00Z"),
+							t1: T("2011-02-03T13:46:00Z"),
+						},
+					},
+					end: position{
+						startOffset: maxOffset,
+					},
+				},
+			},
+		},
+		{
+			testName: "time-anchor-second",
+			input:    "[13:45:12.345]",
+			expected: map[int32]interval{
+				-1: {
+					start: position{
+						startIsTime: true,
+						startTime: timeRange{
+							t0: T("2011-02-03T13:45:12.345Z"),
+							t1: T("2011-02-03T13:45:12.345Z"),
+						},
+					},
+					end: position{
+						startOffset: maxOffset,
+					},
+				},
+			},
+		},
+		{
+			testName: "time-anchor-hour",
+			input:    "[4pm]",
+			expected: map[int32]interval{
+				-1: {
+					start: position{
+						startIsTime: true,
+						startTime: timeRange{
+							t0: T("2011-02-03T16:00:00Z"),
+							t1: T("2011-02-03T17:00:00Z"),
+						},
+					},
+					end: position{
+						startOffset: maxOffset,
+					},
+				},
+			},
+		},
+		{
+			testName: "time-range",
+			input:    "[2019-08-31T13:06:08.234Z]:[2023-02-05T12:01:02.6789Z]",
+			expected: map[int32]interval{
+				-1: {
+					start: position{
+						startIsTime: true,
+						startTime: timeRange{
+							t0: T("2019-08-31T13:06:08.234Z"),
+							t1: T("2019-08-31T13:06:08.234Z"),
+						},
+					},
+					end: position{
+						startIsTime: true,
+						startTime: timeRange{
+							t0: T("2023-02-05T12:01:02.6789Z"),
+							t1: T("2023-02-05T12:01:02.6789Z"),
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "time-anchor-with-diff-offset",
+			input:    "[4pm]-123",
+			expected: map[int32]interval{
+				-1: {
+					start: position{
+						startIsTime: true,
+						startTime: timeRange{
+							t0: T("2011-02-03T16:00:00Z"),
+							t1: T("2011-02-03T17:00:00Z"),
+						},
+						diffOffset: -123,
+					},
+					end: position{
+						startOffset: maxOffset,
+					},
+				},
+			},
+		},
+		{
+			testName: "offset-anchor-with-negative-time-rel",
+			input:    "1234-1h3s",
+			expected: map[int32]interval{
+				-1: {
+					start: position{
+						startOffset: 1234,
+						diffIsTime:  true,
+						diffTime:    -(time.Hour + 3*time.Second),
+					},
+					end: position{
+						startOffset: maxOffset,
+					},
+				},
+			},
+		},
+		{
+			testName: "offset-anchor-with-positive-time-rel",
+			input:    "1234+555ms",
+			expected: map[int32]interval{
+				-1: {
+					start: position{
+						startOffset: 1234,
+						diffIsTime:  true,
+						diffTime:    555 * time.Millisecond,
+					},
+					end: position{
+						startOffset: maxOffset,
+					},
+				},
+			},
+		},
+		{
+			testName: "time-anchor-combines-with-time-rel",
+			input:    "[3pm]+5s",
+			expected: map[int32]interval{
+				-1: {
+					start: position{
+						startIsTime: true,
+						startTime: timeRange{
+							t0: T("2011-02-03T15:00:05Z"),
+							t1: T("2011-02-03T16:00:05Z"),
+						},
+					},
+					end: position{
+						startOffset: maxOffset,
+					},
+				},
+			},
+		},
+		// TODO error cases
+		// TODO local time resolution
 	}
-
+	c := qt.New(t)
+	// Choose a reference date that's not UTC, so we can ensure
+	// that the timezone-dependent logic works correctly.
+	now := T("2011-02-03T16:05:06.500Z").In(time.FixedZone("UTC-8", -8*60*60))
 	for _, d := range data {
-		t.Run(d.testName, func(t *testing.T) {
-			actual, err := parseOffsets(d.input)
+		c.Run(d.testName, func(c *qt.C) {
+			actual, err := parseOffsets(d.input, now)
 			if d.expectedErr != "" {
-				if err == nil {
-					t.Fatalf("got no error; want error %q", d.expectedErr)
-				}
-				if got, want := err.Error(), d.expectedErr; got != want {
-					t.Fatalf("got unexpected error %q want %q", got, want)
-				}
+				c.Assert(err, qt.ErrorMatches, d.expectedErr)
 				return
 			}
-			if !reflect.DeepEqual(actual, d.expected) {
-				t.Errorf(
-					`
-Expected: %+v, err=%v
-Actual:   %+v, err=%v
-Input:    %v
-	`,
-					d.expected,
-					d.expectedErr,
-					actual,
-					err,
-					d.input,
-				)
-			}
+			c.Assert(err, qt.Equals, nil)
+			c.Assert(actual, deepEquals, d.expected)
 		})
 	}
 }
@@ -424,7 +659,10 @@ func TestFindPartitionsToConsume(t *testing.T) {
 		{
 			topic: "a",
 			offsets: map[int32]interval{
-				10: {offset{false, 2, 0}, offset{false, 4, 0}},
+				10: {
+					start: position{startOffset: 2},
+					end:   position{startOffset: 4},
+				},
 			},
 			consumer: tConsumer{
 				topics:              []string{"a"},
@@ -440,7 +678,10 @@ func TestFindPartitionsToConsume(t *testing.T) {
 		{
 			topic: "a",
 			offsets: map[int32]interval{
-				-1: {offset{false, 3, 0}, offset{false, 41, 0}},
+				-1: {
+					start: position{startOffset: 3},
+					end:   position{startOffset: 41},
+				},
 			},
 			consumer: tConsumer{
 				topics:              []string{"a"},
@@ -496,7 +737,7 @@ func TestConsume(t *testing.T) {
 	target.topic = "hans"
 	target.brokers = []string{"localhost:9092"}
 	target.offsets = map[int32]interval{
-		-1: interval{start: offset{false, 1, 0}, end: offset{false, 5, 0}},
+		-1: interval{start: position{startOffset: 1}, end: position{startOffset: 5}},
 	}
 
 	go target.consume(partitions)
@@ -656,3 +897,15 @@ func TestConsumeParseArgs(t *testing.T) {
 		return
 	}
 }
+
+func T(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+// deepEquals allows comparison of the unexported fields inside the
+// value returned by parseOffsets.
+var deepEquals = qt.CmpEquals(cmp.AllowUnexported(position{}, interval{}, timeRange{}))

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ require (
 	github.com/eapache/go-resiliency v1.1.0 // indirect
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
+	github.com/frankban/quicktest v1.4.1
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
+	github.com/google/go-cmp v0.3.0
 	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,17 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
+github.com/frankban/quicktest v1.4.1 h1:Wv2VwvNn73pAdFIVUQRXYDFp31lXKbqblIXo/Q5GPSg=
+github.com/frankban/quicktest v1.4.1/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60qkgn7rorfQ=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
+github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
This is a preparatory step before implementing full time-based
queries in kt. We change the offsets syntax so that it allows
time-based positions, including duration-based relative
positions. To avoid the grammatical conflict from the presence
of colons in time representations, times are enclosed in square
brackets.

Adding times makes the current "offset" type name a little
awkward, as it's hard to distinguish between "offset" as a
way of describing a numerical offset and "offset" as a term
for a description of a position within a stream. To make that clearer
in the code, we rename the `offset` type to `position`.
We also refactor that type so that it can represent both
time and offset-based start and differences, and to remove the
redundant isRelative boolean flag (OffsetOldest and friends are
more "symbolic" than "relative" anyway).

To enable straightforward comparison of position values without
using DeepEquals (which is problematic with time.Time), we
change `TestParseOffsets` to use the quicktest package. There
may be some advantage to using that package for testing throughout
in the future for self-consistency and better test error reports.