### PR TITLE
code cleanup

### DIFF
--- a/consume_test.go
+++ b/consume_test.go
@@ -680,7 +680,10 @@ func TestFindPartitionsToConsume(t *testing.T) {
 			topic:    d.topic,
 			offsets:  d.offsets,
 		}
-		actual := target.findPartitions()
+		actual, err := target.findPartitions()
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		if !reflect.DeepEqual(actual, d.expected) {
 			t.Errorf(


### PR DESCRIPTION
Avoid use of var blocks unless necessary.

Avoid use of failf (which calls os.Exit) - it can easily end up with defers
not being called. Return errors instead.

Use more general code to default flag values to environment
variable values.