### PR TITLE
implement time offset semantics

### DIFF
--- a/consume_test.go
+++ b/consume_test.go
@@ -643,15 +643,14 @@ func TestConsume(t *testing.T) {
 		},
 		calls: calls,
 	}
-	partitions := []int32{1, 2}
 	target := consumeCmd{consumer: consumer}
 	target.topic = "hans"
 	target.brokers = []string{"localhost:9092"}
-	target.offsets = map[int32]interval{
-		-1: interval{start: positionAtOffset(1), end: positionAtOffset(5)},
-	}
 
-	go target.consume(partitions)
+	go target.consume(map[int32]resolvedInterval{
+		1: {1, 5},
+		2: {1, 5},
+	})
 	defer close(closer)
 
 	var actual []tConsumePartition

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fgeller/kt
+module github.com/heetch/hkt
 
 require (
 	github.com/Shopify/sarama v1.19.0
@@ -10,6 +10,7 @@ require (
 	github.com/frankban/quicktest v1.4.1
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/google/go-cmp v0.3.0
+	github.com/kr/pretty v0.1.0
 	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165 // indirect
 	github.com/rogpeppe/go-internal v1.4.0

--- a/offsetparse.go
+++ b/offsetparse.go
@@ -42,6 +42,12 @@ type position struct {
 	diff   anchorDiff
 }
 
+// resolved reports whether the position has been
+// fully resolved to an absolute offset.
+func (p position) resolved() bool {
+	return !p.anchor.isTime && p.anchor.offset >= 0 && !p.diff.isDuration && p.diff.offset == 0
+}
+
 // anchor represents an absolute offset in the position stream.
 type anchor struct {
 	// isTime specifies which anchor field is valid.

--- a/offsetquery.go
+++ b/offsetquery.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"golang.org/x/sync/errgroup"
+)
+
+// offsetQueryer knows how to send bulk offset queries to Kafka.
+type offsetQueryer struct {
+	topic    string
+	client   sarama.Client
+	consumer sarama.Consumer
+}
+
+// runQuery runs the given offset query and puts the results into info.
+func (r *offsetQueryer) runQuery(ctx context.Context, q *offsetQuery, info *offsetInfo) error {
+	egroup, ctx := errgroup.WithContext(ctx)
+	egroup.Go(func() error {
+		return r.getTimes(ctx, q.timeQuery, info)
+	})
+	egroup.Go(func() error {
+		return r.getOffsets(ctx, q.offsetQuery, info)
+	})
+	egroup.Go(func() error {
+		return r.getResumes(ctx, q.resumeQuery, info)
+	})
+	if err := egroup.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *offsetQueryer) getTimes(ctx context.Context, q map[int32]map[int64]bool, info *offsetInfo) error {
+	type result struct {
+		partition int32
+		offset    int64
+		time      time.Time
+	}
+	resultc := make(chan result)
+	nrequests := 0
+	egroup, ctx := errgroup.WithContext(ctx)
+	for p, offsets := range q {
+		p := p
+		// getOffset should never fail because getTime should have ensured
+		// that the newest-offset info is present. If it does, it'll panic before
+		// it returns due to assigning to the new query value.
+		newestOffset, _ := info.getOffset(p, symbolicOffsetRequest(sarama.OffsetNewest), nil)
+		for offset := range offsets {
+			offset := offset
+			if offset < 0 {
+				panic("symbolic offset passed to getTime")
+			}
+			nrequests++
+			egroup.Go(func() error {
+				consumeOffset := offset
+				if consumeOffset == newestOffset && newestOffset > 0 {
+					// We're asking about the time of the newest offset. Although the newest
+					// offset is one beyond the last message, we make a special case
+					// for this, as finding the time of the last message is common.
+					consumeOffset--
+				}
+				if consumeOffset >= newestOffset {
+					// No way to know what the timestamp is, so send a zero timestamp
+					// to signify that fact.
+					resultc <- result{
+						partition: p,
+						offset:    offset,
+					}
+					return nil
+				}
+				// TODO batch fetch requests.
+				mt, err := fetchOneMessageTimestamp(r.client, r.topic, p, consumeOffset)
+				if err != nil {
+					return err
+				}
+				resultc <- result{
+					partition: p,
+					offset:    offset,
+					time:      mt,
+				}
+				return nil
+			})
+		}
+	}
+	egroup.Go(func() error {
+		for i := 0; i < nrequests; i++ {
+			select {
+			case result := <-resultc:
+				info.setTime(result.partition, result.offset, result.time)
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return nil
+	})
+	return egroup.Wait()
+}
+
+func (r *offsetQueryer) getResumes(ctx context.Context, q map[int32]bool, info *offsetInfo) error {
+	if len(q) == 0 {
+		return nil
+	}
+	return fmt.Errorf("not yet implemented")
+	//	for p := range q {
+	//		// get partition manager for partition
+	//		info.setResumeOffset(pom.NextOffset())
+	//	}
+	//	return nil
+}
+
+// getOffsets gets offsets for all the requests in q and stores the results by calling info.setOffset.
+// Note that this does not resolve resume offset requests, which are handled by getResumes.
+func (r *offsetQueryer) getOffsets(ctx context.Context, q map[int32]map[offsetRequest]bool, info *offsetInfo) error {
+	type result struct {
+		askFor map[int32]offsetRequest
+		resp   *sarama.OffsetResponse
+		err    error
+	}
+	// This is unbuffered so if we fail, we'll leave some dangling goroutines that will block trying to
+	// write to resultc, but as the whole command is going to exit in that case, we don't care.
+	resultc := make(chan result)
+
+	nqueries := 0
+	// We can only ask about one partition per request, so keep issuing requests
+	// until we have no more left to ask about.
+	for len(q) > 0 {
+		// We're going to issue a request for each unique broker that manages
+		// any of the partitions in the query.
+		reqs := make(map[*sarama.Broker]*sarama.OffsetRequest)
+
+		// askFor records the partitions that we're asking about,
+		// so we can make sure the broker has responded with
+		// the expected information, otherwise there's a risk
+		// that a broker with broken behaviour could cause
+		// getOffsetsForTimes to fail to fill out the required info
+		// in info, which could cause an infinite loop in the calling
+		// logic which expects all queries to get an answer.
+		askFor := make(map[*sarama.Broker]map[int32]offsetRequest)
+		for p, offqs := range q {
+			if len(offqs) == 0 {
+				// Defensive: this shouldn't happen.
+				delete(q, p)
+				continue
+			}
+			var offq offsetRequest
+			for offq = range offqs {
+				delete(offqs, offq)
+				break
+			}
+			if len(offqs) == 0 {
+				delete(q, p)
+			}
+			if offq.timeOrOff == offsetResume {
+				panic("getOffsets called with offsetResume query")
+			}
+			b, err := r.client.Leader(r.topic, p)
+			if err != nil {
+				return err
+			}
+			req := reqs[b]
+			if req == nil {
+				req = &sarama.OffsetRequest{
+					Version: 1,
+				}
+				reqs[b] = req
+				askFor[b] = make(map[int32]offsetRequest)
+			}
+			req.AddBlock(r.topic, p, offq.timeOrOff, 1)
+			askFor[b][p] = offq
+		}
+		for b, req := range reqs {
+			b, req := b, req
+			nqueries++
+			go func() {
+				// We should pass ctx here but sarama doesn't support context.
+				resp, err := b.GetAvailableOffsets(req)
+				resultc <- result{
+					askFor: askFor[b],
+					resp:   resp,
+					err:    err,
+				}
+			}()
+		}
+	}
+	for i := 0; i < nqueries; i++ {
+		select {
+		case result := <-resultc:
+			ps, ok := result.resp.Blocks[r.topic]
+			if !ok {
+				return fmt.Errorf("topic %q not found in offsets response", r.topic)
+			}
+			for p, offq := range result.askFor {
+				block, ok := ps[p]
+				if !ok {
+					return fmt.Errorf("no offset found for partition %d", p)
+				}
+				if block.Err != 0 {
+					return fmt.Errorf("cannot get offset for partition %d: %v", p, block.Err)
+				}
+				if block.Offset < 0 {
+					// This happens when the time is beyond the last offset.
+					block.Offset = sarama.OffsetNewest // TODO or maxOffset?
+				}
+				info.setOffset(p, offq, block.Offset)
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+func fetchOneMessageTimestamp(client sarama.Client, topic string, partition int32, offset int64) (time.Time, error) {
+	b, err := client.Leader(topic, partition)
+	if err != nil {
+		return time.Time{}, err
+	}
+	req := &sarama.FetchRequest{
+		MinBytes:    1,
+		MaxWaitTime: 1,
+		// TODO better version-picking logic.
+		Version: 4,
+	}
+	req.AddBlock(topic, partition, offset, 1024*1024)
+	resp, err := b.Fetch(req)
+	if err != nil {
+		return time.Time{}, err
+	}
+	block := resp.Blocks[topic][partition]
+	if block == nil {
+		return time.Time{}, fmt.Errorf("no block found in response")
+	}
+	if block.Err != 0 {
+		// possible errors:
+		// ErrOffsetOutOfRange:
+		// ErrUnknownTopicOrPartition, ErrNotLeaderForPartition, ErrLeaderNotAvailable, ErrReplicaNotAvailable:
+		return time.Time{}, fmt.Errorf("fetch error: %v", block.Err)
+	}
+	if len(block.RecordsSet) == 0 {
+		return time.Time{}, fmt.Errorf("no record sets found in fetch response")
+	}
+	for _, records := range block.RecordsSet {
+		batch := records.RecordBatch
+		if batch == nil {
+			return time.Time{}, fmt.Errorf("can't deal with legacy fetch response")
+		}
+		for _, r := range batch.Records {
+			if batch.FirstOffset+r.OffsetDelta >= offset {
+				return batch.FirstTimestamp.Add(r.TimestampDelta), nil
+			}
+		}
+	}
+	return time.Time{}, fmt.Errorf("no record found")
+}

--- a/offsetresolve.go
+++ b/offsetresolve.go
@@ -1,0 +1,438 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Shopify/sarama"
+)
+
+// resolveOffsets resolves the given per-partition intervals to absolute intervals.
+func (cmd *consumeCmd) resolveOffsets(ctx context.Context, offsets map[int32]interval) (map[int32]resolvedInterval, error) {
+	r, err := cmd.newResolver()
+	if err != nil {
+		return nil, err
+	}
+	return r.resolveOffsets(ctx, offsets)
+}
+
+func (cmd *consumeCmd) newResolver() (*resolver, error) {
+	allPartitions, err := cmd.consumer.Partitions(cmd.topic)
+	if err != nil {
+		return nil, err
+	}
+	queryer := &offsetQueryer{
+		topic:    cmd.topic,
+		client:   cmd.client,
+		consumer: cmd.consumer,
+	}
+	return &resolver{
+		truncate:      !cmd.follow,
+		runQuery:      queryer.runQuery,
+		topic:         cmd.topic,
+		allPartitions: allPartitions,
+		info: offsetInfo{
+			offsets: make(map[int32]map[offsetRequest]int64),
+			resumes: make(map[int32]int64),
+			times:   make(map[int32]map[int64]time.Time),
+		},
+	}, nil
+}
+
+// resolver is responsible for resolving a set of offsets, as parsed
+// by parseOffsets, into absolute integer offsets.
+type resolver struct {
+	// runQuery is called to make the query to kafka for all items
+	// in q, putting the results into info.
+	runQuery func(ctx context.Context, q *offsetQuery, info *offsetInfo) error
+
+	// When truncate is true, resolved intervals will not extend beyond the
+	// end of their partition.
+	truncate bool
+
+	// topic holds the topic being consumed.
+	topic string
+
+	// allPartitions holds all the partition ids in the Kafka instance.
+	allPartitions []int32
+
+	// info records offset information as it's found.
+	info offsetInfo
+}
+
+type resolvedInterval struct {
+	start, end int64
+}
+
+type offsetRequest struct {
+	// timeOrOff holds the number of milliseconds since Jan 1st 1970 of the
+	// offset to request, or one of offsetResume, sarama.OldestOffset, sarama.NewestOffset
+	// if it's not a time-based request.
+	//
+	// Note that this is in the same form expected by the ListOffset Kakfa API.
+	timeOrOff int64
+}
+
+// offsetQuery represents a set of information to be asked as bulk requests
+// to the Kafka API.
+type offsetQuery struct {
+	timeQuery   map[int32]map[int64]bool
+	offsetQuery map[int32]map[offsetRequest]bool
+	resumeQuery map[int32]bool
+}
+
+func (r *resolver) resolveOffsets(ctx context.Context, offsets map[int32]interval) (map[int32]resolvedInterval, error) {
+	allOffsets := make(map[int32]*interval)
+	for p, intv := range offsets {
+		intv := intv
+		allOffsets[p] = &intv
+		if p != -1 && !r.partitionExists(p) {
+			return nil, fmt.Errorf("partition %v does not exist", p)
+		}
+	}
+	resolved := make(map[int32]resolvedInterval)
+	// Some offsets can't be resolved in one query (for example, a
+	// offset like "latest-1h" will first need to resolve "latest"
+	// to the latest offset for the partition, then find the
+	// timestamp of the latest message in that partition, then find
+	// the offset of that timestamp less one house). So we keep on
+	// running queries until there are no more left, moving items
+	// out of allOffsets and into resolved when they're fully
+	// resolved.
+	count := 0
+	for len(allOffsets) > 0 {
+		count++
+		if count > 20 {
+			panic("probable infinite loop resolving offsets")
+		}
+		// We want to minimise the number of queries we make to
+		// the server, so instead of querying each position
+		// directly, we build up all the query requirements in
+		// q, then call runOffsetQuery which will build bulk API
+		// calls as needed, and fill in entries inside info,
+		// which can then be used to satisfy subsequent
+		// information requirements in resolvePosition.
+		q := &offsetQuery{
+			timeQuery:   make(map[int32]map[int64]bool),
+			offsetQuery: make(map[int32]map[offsetRequest]bool),
+			resumeQuery: make(map[int32]bool),
+		}
+		r.expandAllIntervalsSpec(allOffsets, q)
+		for p, intv := range allOffsets {
+			if p == -1 {
+				continue
+			}
+			partitionMax, haveMax := lastPosition(), true
+			if r.truncate {
+				// Find out where the partition ends so we can constrain the interval.
+				partitionMax, haveMax = resolvePosition(p, newestPosition(), &r.info, q)
+			}
+			start, ok1 := resolvePosition(p, intv.start, &r.info, q)
+			end, ok2 := resolvePosition(p, intv.end, &r.info, q)
+			intv.start, intv.end = start, end
+			if ok1 && ok2 && haveMax {
+				// The interval has been fully resolved,
+				// so remove it from allOffsets and add
+				// it to resolved.
+				delete(allOffsets, p)
+				if start.resolved() && end.resolved() {
+					resolved[p] = resolvedInterval{
+						start: min(start.anchor.offset, partitionMax.anchor.offset),
+						end:   min(end.anchor.offset, partitionMax.anchor.offset),
+					}
+				}
+			}
+		}
+		if err := r.runQuery(ctx, q, &r.info); err != nil {
+			return nil, err
+		}
+	}
+	return resolved, nil
+}
+
+// expandAllIntervalsSpec expands the "all partitions" entry in offsets if present,
+// creating entries for all partitions not explicitly specified in offsets.
+//
+// If there isn't enough information in q to do that, it leaves
+// the offsets map unchanged.
+func (r *resolver) expandAllIntervalsSpec(offsets map[int32]*interval, q *offsetQuery) {
+	intv, ok := offsets[-1]
+	if !ok {
+		// No "all partitions" entry.
+		return
+	}
+	// updateTimestamp updates the "summary" timestamp *t according to p.
+	// It only affects t if p has either an "oldest" or "newest" anchor with
+	// a duration-based difference which implies that we need to find either the
+	// oldest or newest timestamp across all partitions so that the
+	// interval end time is the same across all partitions.
+	updateTimestamp := func(t *time.Time, partition int32, p position) bool {
+		if p.anchor.offset >= 0 || !p.diff.isDuration || p.anchor.offset == offsetResume {
+			// We can work out the "all" offset for each partition independently.
+			// Lacking a better idea, we leave resume as per-partition.
+			return true
+		}
+		off, ok := r.info.getOffset(partition, symbolicOffsetRequest(p.anchor.offset), q)
+		if !ok {
+			return false
+		}
+		t1, ok := r.info.getTime(partition, off, q)
+		if !ok {
+			return false
+		}
+		if t1.IsZero() {
+			// No timestamp available (probably because the partition is empty)
+			return true
+		}
+		switch p.anchor.offset {
+		case sarama.OffsetOldest:
+			if t1.Before(*t) {
+				*t = t1
+			}
+		case sarama.OffsetNewest:
+			if (*t).IsZero() || t1.After(*t) {
+				*t = t1
+			}
+		}
+		return true
+	}
+	var startTime, endTime time.Time
+	gotAll := true
+	for _, partition := range r.allPartitions {
+		if _, ok := offsets[partition]; ok {
+			// The partition was explicitly specified, so it's independent.
+			continue
+		}
+		gotAll = updateTimestamp(&startTime, partition, intv.start) && gotAll
+		gotAll = updateTimestamp(&endTime, partition, intv.end) && gotAll
+	}
+	if !gotAll {
+		return
+	}
+	// We've got enough information to fill out the offsets we need.
+	// First update the "all partitions" interval to be the correct time if needed.
+	// Note that if startTime or endTime are zero (because all partitions
+	// are empty for example), we'll leave the interval to be resolved later,
+	// which should work out fine in the end.
+	if !startTime.IsZero() {
+		intv.start.anchor.isTime = true
+		intv.start.anchor.time = startTime.Add(intv.start.diff.duration)
+		intv.start.diff = anchorDiff{}
+	}
+	if !endTime.IsZero() {
+		intv.end.anchor.isTime = true
+		intv.end.anchor.time = endTime.Add(intv.end.diff.duration)
+		intv.end.diff = anchorDiff{}
+	}
+	delete(offsets, -1)
+	for _, partition := range r.allPartitions {
+		if _, ok := offsets[partition]; ok {
+			continue
+		}
+		intv := *intv
+		offsets[partition] = &intv
+	}
+}
+
+func min(x, y int64) int64 {
+	if x < y {
+		return x
+	}
+	return y
+}
+
+func (r *resolver) partitionExists(p int32) bool {
+	for _, ap := range r.allPartitions {
+		if ap == p {
+			return true
+		}
+	}
+	return false
+}
+
+// resolvePosition tries to resolve p in the given partition from information provided in info.
+// It reports whether the position has been resolved or cannot be resolved.
+//
+// If it returns false, it will have added at least one thing to be queried to q in
+// order to proceed with the resolution.
+//
+// The returned position is always valid, and may contain updated information.
+func resolvePosition(partition int32, p position, info *offsetInfo, q *offsetQuery) (_pos position, _ok bool) {
+	if !p.anchor.isTime && p.anchor.offset >= 0 && !p.diff.isDuration && p.diff.offset == 0 {
+		return p, true
+	}
+	if p.anchor.isTime {
+		if p.diff.isDuration {
+			panic("position has time anchor and duration diff")
+		}
+		off, ok := info.getOffset(partition, timeOffsetRequest(p.anchor.time), q)
+		if !ok {
+			return p, false
+		}
+		p.anchor.isTime = false
+		p.anchor.offset = off
+		if off >= 0 {
+			p.anchor.offset += p.diff.offset
+			p.diff = anchorDiff{}
+			return p, true
+		}
+		// The time has resolved to a symbolic offset, which happens
+		// when the time query is beyond the end of the topic.
+		// Let the offset resolving logic below deal with that.
+	}
+	if p.anchor.offset < 0 {
+		off, ok := info.getOffset(partition, symbolicOffsetRequest(p.anchor.offset), q)
+		if !ok {
+			return p, false
+		}
+		p.anchor.offset = off
+	}
+	if !p.diff.isDuration {
+		p.anchor.offset += p.diff.offset
+		p.diff = anchorDiff{}
+		return p, true
+	}
+	// It's a non-symbolic offset anchor with a duration diff.
+	// Find the time for the offset.
+	t, ok := info.getTime(partition, p.anchor.offset, q)
+	if !ok {
+		return p, false
+	}
+	if t.IsZero() {
+		// No timestamp is available, so we can't resolve the position properly,
+		// so just return to unresolved position.
+		return p, true
+	}
+	// Then get the offset for the anchor time plus the anchor diff duration.
+	off, ok := info.getOffset(partition, timeOffsetRequest(t.Add(p.diff.duration)), q)
+	if !ok {
+		return p, false
+	}
+	p.anchor.offset = off
+	p.diff = anchorDiff{}
+	if off >= 0 {
+		return p, true
+	}
+	// The time query has resulted in a symbolic offset, so we need to
+	// find the absolute offset for it.
+	off1, ok := info.getOffset(partition, symbolicOffsetRequest(off), q)
+	if !ok {
+		return p, false
+	}
+	p.anchor.offset = off1
+	return p, true
+}
+
+type offsetInfo struct {
+	// offsets maps from partition to offset request to offset.
+	// This holds results from both time-based queries and symbolic
+	// offset queries (as determined by the offset request itself).
+	//
+	// Note that the resulting offset value may itself by symbolic,
+	// as a request for a time beyond the last available time
+	// may result in a reference to the last available offset.
+	offsets map[int32]map[offsetRequest]int64
+
+	// resumes maps from partition to the resume offset for that partition.
+	// This is kept separately from offsets because it's updated by
+	// a different goroutine so we can avoid a mutex.
+	resumes map[int32]int64
+
+	// offsetTimes maps from partition to offset to the timestamp for that offset in that partition.
+	times map[int32]map[int64]time.Time
+}
+
+// getOffset returns the offset for a given time or symbolic offset.
+func (info *offsetInfo) getOffset(p int32, req offsetRequest, q *offsetQuery) (int64, bool) {
+	if req.timeOrOff == offsetResume {
+		// Resume offset queries are resolved with a different kind of API request,
+		// so they go into a different field in the query.
+		if off, ok := info.resumes[p]; ok {
+			return off, true
+		}
+		q.resumeQuery[p] = true
+		return 0, false
+	}
+	if off, ok := info.offsets[p][req]; ok {
+		return off, true
+	}
+	if q.offsetQuery[p] == nil {
+		q.offsetQuery[p] = make(map[offsetRequest]bool)
+	}
+	q.offsetQuery[p][req] = true
+	return 0, false
+}
+
+func (info *offsetInfo) setOffset(p int32, req offsetRequest, off int64) {
+	if req.timeOrOff == offsetResume {
+		panic("setOffset called with resume offset")
+	}
+	if info.offsets[p] == nil {
+		info.offsets[p] = make(map[offsetRequest]int64)
+	}
+	info.offsets[p][req] = off
+}
+
+func (info *offsetInfo) setResumeOffset(p int32, off int64) {
+	info.resumes[p] = off
+}
+
+func (info *offsetInfo) getTime(p int32, off int64, q *offsetQuery) (time.Time, bool) {
+	if off < 0 {
+		panic("getTime called with symbolic offset")
+	}
+	// So that we can avoid blocking if the offset is beyond the end of the
+	// partition, the queryer needs the offset of the last message in the partition,
+	// so ensure that's available.
+	// If the offset is beyond the end, we won't be able to get a time
+	// for it, but we can't return an error here, so leave it to the offsetQueryer
+	// to do that for us.
+	_, ok := info.getOffset(p, symbolicOffsetRequest(sarama.OffsetNewest), q)
+	if !ok {
+		return time.Time{}, false
+	}
+	t, ok := info.times[p][off]
+	if ok {
+		return t, true
+	}
+	if q.timeQuery[p] == nil {
+		q.timeQuery[p] = make(map[int64]bool)
+	}
+	q.timeQuery[p][off] = true
+	return time.Time{}, false
+}
+
+func (info *offsetInfo) setTime(p int32, off int64, t time.Time) {
+	if info.times[p] == nil {
+		info.times[p] = make(map[int64]time.Time)
+	}
+	info.times[p][off] = t
+}
+
+func timeOffsetRequest(t time.Time) offsetRequest {
+	return offsetRequest{
+		timeOrOff: unixMilliseconds(t),
+	}
+}
+
+func symbolicOffsetRequest(off int64) offsetRequest {
+	if off >= 0 {
+		panic("symbolicOffsetRequest called with non-symbolic offset")
+	}
+	return offsetRequest{
+		timeOrOff: off,
+	}
+}
+
+func unixMilliseconds(t time.Time) int64 {
+	ns := time.Duration(t.UnixNano())
+	return int64(ns / time.Millisecond)
+}
+
+func fromUnixMilliseconds(ts int64) time.Time {
+	if ts <= 0 {
+		return time.Time{}
+	}
+	return time.Unix(ts/1000, (ts%1000)*1e6)
+}

--- a/offsetresolve_test.go
+++ b/offsetresolve_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bufio"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/google/go-cmp/cmp"
+)
+
+var epoch = mustParseTime("2010-01-02T12:00:00+02:00")
+
+var resolveTestData = `
+0 100r20 12:00 +2s +3s 13:00 +2s
+1 50 09:00 10:00
+
+all=0:newest
+0 100 104
+1 50 52
+
+all=0:
+0 100 104
+1 50 52
+
+all=:newest
+0 100 104
+1 50 52
+
+0=:
+0 100 104
+
+0=100:103
+0 100 103
+
+----
+
+`
+
+type resolveTestGroup struct {
+	times   map[int32][]time.Time
+	offsets map[int32]int64
+	resumes map[int32]int64
+
+	tests []resolveTest
+}
+
+type resolveTest struct {
+	offsets string
+	expect  map[int32]resolvedInterval
+}
+
+func parseResolveTests(c *qt.C, testStr string) []resolveTestGroup {
+	blocks := strings.Split(testStr, "\n----\n")
+	groups := make([]resolveTestGroup, len(blocks))
+	for i, b := range blocks {
+		groups[i] = parseResolveGroup(c, b)
+	}
+	return groups
+}
+
+func TestParseResolveTests(t *testing.T) {
+	c := qt.New(t)
+	// Sanity-check the parseResolveGroup code.
+	gs := parseResolveTests(c, `
+0 100r20 +0 +2s +3s +59m55s +2s
+1 50 2001-10-23T01:03:00Z +1h
+
+all=0:newest
+0 100 104
+1 50 52
+
+all=0:
+2 3 5
+3 50 52
+`[1:])
+	c.Assert(gs, qt.CmpEquals(cmp.AllowUnexported(
+		resolveTestGroup{},
+		resolveTest{},
+		resolvedInterval{},
+	)), []resolveTestGroup{{
+		times: map[int32][]time.Time{
+			0: {
+				epoch,
+				epoch.Add(2 * time.Second),
+				epoch.Add(5 * time.Second),
+				epoch.Add(time.Hour),
+				epoch.Add(time.Hour + 2*time.Second),
+			},
+			1: {
+				mustParseTime("2001-10-23T01:03:00Z"),
+				mustParseTime("2001-10-23T02:03:00Z"),
+			},
+		},
+		resumes: map[int32]int64{0: 20},
+		offsets: map[int32]int64{0: 100, 1: 50},
+		tests: []resolveTest{{
+			offsets: "all=0:newest",
+			expect: map[int32]resolvedInterval{
+				0: {100, 104},
+				1: {50, 52},
+			},
+		}, {
+			offsets: "all=0:",
+			expect: map[int32]resolvedInterval{
+				2: {3, 5},
+				3: {50, 52},
+			},
+		}},
+	}})
+}
+
+func parseResolveGroup(c *qt.C, block string) resolveTestGroup {
+	g := resolveTestGroup{
+		times:   make(map[int32][]time.Time),
+		offsets: make(map[int32]int64),
+		resumes: make(map[int32]int64),
+	}
+	scan := bufio.NewScanner(strings.NewReader(block))
+	for {
+		if !scan.Scan() {
+			c.Fatalf("unexpected end of resolve test block")
+		}
+		pfields := strings.Fields(scan.Text())
+		if len(pfields) == 0 {
+			break
+		}
+		if len(pfields) < 2 {
+			c.Fatalf("too few fields in line %q", scan.Text())
+		}
+		partition, err := strconv.Atoi(pfields[0])
+		c.Assert(err, qt.Equals, nil)
+		offs := strings.Split(pfields[1], "r")
+		startOffset, err := strconv.ParseInt(offs[0], 10, 64)
+		c.Assert(err, qt.Equals, nil)
+		g.offsets[int32(partition)] = startOffset
+		if len(offs) > 1 {
+			resumeOffset, err := strconv.ParseInt(offs[1], 10, 64)
+			c.Assert(err, qt.Equals, nil)
+			g.resumes[int32(partition)] = resumeOffset
+		}
+		msgs := pfields[2:]
+		times := make([]time.Time, len(msgs))
+		t := epoch
+		for i, m := range msgs {
+			if strings.HasPrefix(m, "+") {
+				d, err := time.ParseDuration(m[1:])
+				c.Assert(err, qt.Equals, nil)
+				t = t.Add(d)
+				times[i] = t
+				continue
+			}
+			msgTime, err := time.Parse(time.RFC3339, m)
+			c.Assert(err, qt.Equals, nil, qt.Commentf("line %q; field %d of %q", scan.Text(), i, msgs))
+			if msgTime.Before(t) && i > 0 {
+				c.Fatalf("out of order test messages")
+			}
+			times[i] = msgTime
+			t = msgTime
+		}
+		g.times[int32(partition)] = times
+	}
+	for scan.Scan() {
+		test := resolveTest{
+			offsets: scan.Text(),
+			expect:  make(map[int32]resolvedInterval),
+		}
+		for scan.Scan() {
+			fields := strings.Fields(scan.Text())
+			if len(fields) == 0 {
+				break
+			}
+			if len(fields) != 3 {
+				c.Fatalf("expected three fields in a resolved offset for a partition, got %q", scan.Text())
+			}
+			partition, err := strconv.Atoi(fields[0])
+			c.Assert(err, qt.Equals, nil)
+			start, err := strconv.ParseInt(fields[1], 10, 64)
+			c.Assert(err, qt.Equals, nil)
+			end, err := strconv.ParseInt(fields[2], 10, 64)
+			c.Assert(err, qt.Equals, nil)
+			test.expect[int32(partition)] = resolvedInterval{
+				start: start,
+				end:   end,
+			}
+		}
+		g.tests = append(g.tests, test)
+	}
+	return g
+}
+
+//// TestResolver tests the resolver.ResolveOffsets method
+//// independently of Kafka itself.
+//func TestResolverResolveOffsets(t *testing.T) {
+//	c := qt.New(t)
+//	testGroups := parseResolveTests(c, resolveTestData)
+//	for i, g := range testGroups {
+//		c.Run(fmt.Sprintf("group%d", i), func(c *qt.C) {
+//			c.Parallel()
+//			topic := makeTopic(c)
+//			for partition, startOff := range g.offsets {
+//				for _, m :=
+//		})
+//	}
+//}
+
+func mustParseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/testdata/system.txt
+++ b/testdata/system.txt
@@ -9,7 +9,7 @@ kt produce -topic $topic
 cmpenvjson stdout '{"count": 1, "partition": 0, "startOffset": 0}'
 
 # 2
-kt consume -topic $topic -timeout 500ms -group hans
+kt consume -f -topic $topic -timeout 500ms -group hans
 stderr 'consuming from partition 0 timed out after 500ms'
 cmpenvjson stdout '{"value": "hello 1", "key": "boom", "partition": 0, "offset": 0, "timestamp": "$now"}'
 


### PR DESCRIPTION
This resolves the offsets as parsed by parseOffsets
into absolute partition offsets.

It also adds a `-f` (follow) flag to the `consume` command;
specifying this all allow the consumer to block waiting for
new messages; otherwise t will stop when it reaches its limit.

As there can be many partitions, we take some care
to issue bulk requests rather than send potentially
thousands of concurrent API requests.

Partition resume support is left unimplemented for now;
it's not important for our use case anyway.

Testing has fallen by the wayside for now in the interests of getting
some immediate value out of this.
