### PR TITLE
use testscript for system tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,9 @@ require (
 	github.com/google/go-cmp v0.3.0
 	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165 // indirect
+	github.com/rogpeppe/go-internal v1.4.0
 	golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20181005133103-4497e2df6f9e // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -25,7 +25,16 @@ github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165 h1:nkcn14uNmFEuGCb2mBZbBb24RdNRL08b/wb+xBOYpuk=
 github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/rogpeppe/go-internal v1.3.2 h1:XU784Pr0wdahMY2bYcyK6N1KuaRAdLtqD4qd8D18Bfs=
+github.com/rogpeppe/go-internal v1.3.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.4.0 h1:LUa41nrWTQNGhzdsZ5lTnkwbNjj6rXTdazA1cSdjkOY=
+github.com/rogpeppe/go-internal v1.4.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4 h1:Vk3wNqEZwyGyei9yq5ekj7frek2u7HUfffJ1/opblzc=
 golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20181005133103-4497e2df6f9e h1:EfdBzeKbFSvOjoIqSZcfS8wp0FBLokGBEs9lz1OtSg0=
 golang.org/x/sys v0.0.0-20181005133103-4497e2df6f9e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/testdata/system.txt
+++ b/testdata/system.txt
@@ -1,0 +1,71 @@
+# 0
+kt admin -createtopic $topic -topicdetail 0-admin/topic.json
+! stderr .
+
+# 1
+stdin 1-produce/stdin.json
+kt produce -topic $topic
+! stderr .
+cmpenvjson stdout '{"count": 1, "partition": 0, "startOffset": 0}'
+
+# 2
+kt consume -topic $topic -timeout 500ms -group hans
+stderr 'consuming from partition 0 timed out after 500ms'
+cmpenvjson stdout '{"value": "hello 1", "key": "boom", "partition": 0, "offset": 0, "timestamp": "$now"}'
+
+# 3
+kt group -topic $topic
+stderr 'found partitions=\[0] for topic='$topic
+cmpenvjson stdout '{"name":"hans","topic":"$topic","offsets":[{"partition":0,"offset":1,"lag":0}]}'
+
+# 4
+stdin 4-produce/stdin.json
+kt produce -topic $topic
+! stderr .
+cmpenvjson stdout '{"count": 1, "partition": 0, "startOffset": 1}'
+
+# 5
+kt consume -topic $topic -offsets all=resume -timeout 500ms -group hans
+stderr 'consuming from partition 0 timed out after 500ms'
+cmpenvjson stdout '{"value": "hello 2", "key": "boom", "partition": 0, "offset": 1, "timestamp": "$now"}'
+
+# 6
+kt group -topic $topic -partitions 0 -group hans -reset 0
+cmpenv stderr 6-group/stderr
+cmpenvjson stdout '{"name":"hans","topic":"$topic","offsets":[{"partition":0,"offset":0,"lag":2}]}'
+
+# 7
+kt group -topic $topic
+cmpenv stderr 7-group/stderr
+cmpenvjson stdout '{"name":"hans","topic":"$topic","offsets":[{"partition":0,"offset":0,"lag":2}]}'
+
+# 8
+kt topic -filter $topic
+! stderr .
+cmpenvjson stdout '{"name":"$topic"}'
+
+# 9
+kt admin -deletetopic $topic
+! stderr .
+! stdout .
+
+# 10
+kt topic -filter $topic
+! stderr .
+! stdout .
+
+-- 0-admin/topic.json --
+{"NumPartitions": 1, "ReplicationFactor": 1}
+-- 1-produce/stdin.json --
+{"value": "hello 1", "key": "boom", "partition": 0}
+-- 4-produce/stdin.json --
+{"value": "hello 2", "key": "boom", "partition": 0}
+-- 6-group/stderr --
+found 1 brokers
+found 1 groups
+found 1 topics
+-- 7-group/stderr --
+found 1 brokers
+found 1 groups
+found 1 topics
+found partitions=[0] for topic=$topic


### PR DESCRIPTION
This makes the system test cleaner (it doesn't need to build another binary, for example), and arguably more readable.
It also paves the way for more end-to-end tests.

Exactly the same sequence of commands is being tested as before, except that some extra output checking is done where there wasn't any before.
