### PR TITLE
remove consumer group consume support

### DIFF
--- a/consume_test.go
+++ b/consume_test.go
@@ -53,15 +53,6 @@ func TestParseOffsets(t *testing.T) {
 			},
 		},
 	}, {
-		testName: "resume",
-		input:    "resume",
-		expected: map[int32]interval{
-			-1: interval{
-				start: positionAtOffset(offsetResume),
-				end:   positionAtOffset(maxOffset),
-			},
-		},
-	}, {
 		testName: "all-with-space",
 		input: "	all ",
 		expected: map[int32]interval{
@@ -160,18 +151,6 @@ func TestParseOffsets(t *testing.T) {
 				start: position{
 					anchor: anchorAtOffset(sarama.OffsetNewest),
 					diff:   anchorDiff{offset: -1},
-				},
-				end: positionAtOffset(maxOffset),
-			},
-		},
-	}, {
-		testName: "resume-relative",
-		input:    "0=resume-10",
-		expected: map[int32]interval{
-			0: interval{
-				start: position{
-					anchor: anchorAtOffset(offsetResume),
-					diff:   anchorDiff{offset: -10},
 				},
 				end: positionAtOffset(maxOffset),
 			},

--- a/offsetparse.go
+++ b/offsetparse.go
@@ -9,10 +9,7 @@ import (
 	"github.com/Shopify/sarama"
 )
 
-const (
-	maxOffset    int64 = 1<<63 - 1
-	offsetResume int64 = -3
-)
+const maxOffset int64 = 1<<63 - 1
 
 type positionRange struct {
 	startAnchor, endAnchor anchor
@@ -57,8 +54,8 @@ type anchor struct {
 	isTime bool
 
 	// offset holds the anchor as an absolute offset.
-	// It can be one of sarama.OffsetOldest, sarama.OffsetNewest
-	// or offsetResume to signify a relative starting position.
+	// It can be sarama.OffsetOldest or sarama.OffsetNewest
+	// to signify a relative starting position.
 	// This field is only significant when isTime is false.
 	offset int64
 
@@ -125,7 +122,7 @@ type interval struct {
 //		relativePosition |
 //		anchorPosition [ relativePosition ]
 //
-//	anchorPosition = number | "newest" | "oldest" | "resume" | "[" { /^]/ } "]"
+//	anchorPosition = number | "newest" | "oldest" | "[" { /^]/ } "]"
 //
 //	relativePosition = ( "+" | "-" ) (number | duration )
 //
@@ -342,8 +339,6 @@ func parseAnchorPos(s string, defaultAnchor anchor, now time.Time) (a0, a1 ancho
 		a = newestAnchor()
 	case "oldest":
 		a = oldestAnchor()
-	case "resume":
-		a = anchor{offset: offsetResume}
 	default:
 		return anchor{}, anchor{}, fmt.Errorf("invalid anchor position %q", s)
 	}

--- a/testdata/system.txt
+++ b/testdata/system.txt
@@ -9,14 +9,9 @@ kt produce -topic $topic
 cmpenvjson stdout '{"count": 1, "partition": 0, "startOffset": 0}'
 
 # 2
-kt consume -f -topic $topic -timeout 500ms -group hans
+kt consume -f -topic $topic -timeout 500ms
 stderr 'consuming from partition 0 timed out after 500ms'
 cmpenvjson stdout '{"value": "hello 1", "key": "boom", "partition": 0, "offset": 0, "timestamp": "$now"}'
-
-# 3
-kt group -topic $topic
-stderr 'found partitions=\[0] for topic='$topic
-cmpenvjson stdout '{"name":"hans","topic":"$topic","offsets":[{"partition":0,"offset":1,"lag":0}]}'
 
 # 4
 stdin 4-produce/stdin.json
@@ -25,31 +20,16 @@ kt produce -topic $topic
 cmpenvjson stdout '{"count": 1, "partition": 0, "startOffset": 1}'
 
 # 5
-kt consume -topic $topic -offsets all=resume -timeout 500ms -group hans
-stderr 'consuming from partition 0 timed out after 500ms'
-cmpenvjson stdout '{"value": "hello 2", "key": "boom", "partition": 0, "offset": 1, "timestamp": "$now"}'
-
-# 6
-kt group -topic $topic -partitions 0 -group hans -reset 0
-cmpenv stderr 6-group/stderr
-cmpenvjson stdout '{"name":"hans","topic":"$topic","offsets":[{"partition":0,"offset":0,"lag":2}]}'
-
-# 7
-kt group -topic $topic
-cmpenv stderr 7-group/stderr
-cmpenvjson stdout '{"name":"hans","topic":"$topic","offsets":[{"partition":0,"offset":0,"lag":2}]}'
-
-# 8
 kt topic -filter $topic
 ! stderr .
 cmpenvjson stdout '{"name":"$topic"}'
 
-# 9
+# 6
 kt admin -deletetopic $topic
 ! stderr .
 ! stdout .
 
-# 10
+# 7
 kt topic -filter $topic
 ! stderr .
 ! stdout .
@@ -60,12 +40,3 @@ kt topic -filter $topic
 {"value": "hello 1", "key": "boom", "partition": 0}
 -- 4-produce/stdin.json --
 {"value": "hello 2", "key": "boom", "partition": 0}
--- 6-group/stderr --
-found 1 brokers
-found 1 groups
-found 1 topics
--- 7-group/stderr --
-found 1 brokers
-found 1 groups
-found 1 topics
-found partitions=[0] for topic=$topic


### PR DESCRIPTION
The `hkt` tool is intended as a debugging tool and shouldn't be interacting with any existing consumer groups. Also, it's not possible in general for a tool that's printing to stdout to know when a given message has been handled and hence when to update the consumer group offset.