### PR TITLE
print  consumed messages in time order

### DIFF
--- a/common.go
+++ b/common.go
@@ -279,3 +279,10 @@ func encoderForType(typ string) (func([]byte) *string, error) {
 		return &s
 	}, nil
 }
+
+func min(x, y int64) int64 {
+	if x < y {
+		return x
+	}
+	return y
+}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/kr/pretty v0.1.0
 	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165 // indirect
-	github.com/rogpeppe/go-internal v1.4.0
+	github.com/rogpeppe/go-internal v1.5.0
 	golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20181005133103-4497e2df6f9e // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/rogpeppe/go-internal v1.3.2 h1:XU784Pr0wdahMY2bYcyK6N1KuaRAdLtqD4qd8D
 github.com/rogpeppe/go-internal v1.3.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.4.0 h1:LUa41nrWTQNGhzdsZ5lTnkwbNjj6rXTdazA1cSdjkOY=
 github.com/rogpeppe/go-internal v1.4.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.5.0 h1:Usqs0/lDK/NqTkvrmKSwA/3XkZAs7ZAW/eLeQ2MVBTw=
+github.com/rogpeppe/go-internal v1.5.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4 h1:Vk3wNqEZwyGyei9yq5ekj7frek2u7HUfffJ1/opblzc=
 golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=

--- a/produce_test.go
+++ b/produce_test.go
@@ -149,7 +149,7 @@ func TestProduceParseArgsFlagsOverrideEnv(t *testing.T) {
 	c.Assert(target.brokers, qt.DeepEquals, []string{"hans:2000"})
 }
 
-func newMessage(key, value string, partition int32) message {
+func newMessage(key, value string, partition int32) producerMessage {
 	var k *string
 	if key != "" {
 		k = &key
@@ -160,7 +160,7 @@ func newMessage(key, value string, partition int32) message {
 		v = &value
 	}
 
-	return message{
+	return producerMessage{
 		Key:       k,
 		Value:     v,
 		Partition: &partition,
@@ -183,7 +183,7 @@ func TestMakeSaramaMessage(t *testing.T) {
 		decodeValue: stringDecoder,
 	}
 	key, value := "key", "value"
-	msg := message{Key: &key, Value: &value}
+	msg := producerMessage{Key: &key, Value: &value}
 	actual, err := target.makeSaramaMessage(msg)
 	c.Assert(err, qt.Equals, nil)
 	c.Assert(string(actual.Key), qt.Equals, key)
@@ -191,7 +191,7 @@ func TestMakeSaramaMessage(t *testing.T) {
 
 	target.decodeKey, target.decodeValue = hexDecoder, hexDecoder
 	key, value = "41", "42"
-	msg = message{Key: &key, Value: &value}
+	msg = producerMessage{Key: &key, Value: &value}
 	actual, err = target.makeSaramaMessage(msg)
 	c.Assert(err, qt.Equals, nil)
 	c.Assert(string(actual.Key), qt.Equals, "A")
@@ -199,7 +199,7 @@ func TestMakeSaramaMessage(t *testing.T) {
 
 	target.decodeKey, target.decodeValue = base64Decoder, base64Decoder
 	key, value = "aGFucw==", "cGV0ZXI="
-	msg = message{Key: &key, Value: &value}
+	msg = producerMessage{Key: &key, Value: &value}
 	actual, err = target.makeSaramaMessage(msg)
 	c.Assert(err, qt.Equals, nil)
 	c.Assert(string(actual.Key), qt.Equals, "hans")
@@ -212,7 +212,7 @@ func TestDeserializeLines(t *testing.T) {
 		literal        bool
 		partition      int32
 		partitionCount int32
-		expected       message
+		expected       producerMessage
 	}{{
 		in:             "",
 		literal:        false,
@@ -250,7 +250,7 @@ func TestDeserializeLines(t *testing.T) {
 				partition:   d.partition,
 			}
 			in := make(chan string, 1)
-			out := make(chan message)
+			out := make(chan producerMessage)
 			go target.deserializeLines(in, out, d.partitionCount)
 			in <- d.in
 

--- a/system_test.go
+++ b/system_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"os"
 	"strings"
 	"testing"
@@ -11,6 +12,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/rogpeppe/go-internal/testscript"
 )
+
+var updateFlag = flag.Bool("update", false, "update testscript scripts to correspond with actual output")
 
 // TestMain allows the test binary to call the top level main
 // function so that it can be invoked by the testscript tests.
@@ -38,17 +41,17 @@ func TestSystem(t *testing.T) {
 	//
 	// It makes a command available that does JSON comparison
 	// (see the cmpenvjson docs).
-	topic := randomString(6)
 	testscript.Run(t, testscript.Params{
 		Dir: "testdata",
 		Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
 			"cmpenvjson": cmpenvjson,
 		},
 		Setup: func(e *testscript.Env) error {
+			topic := randomString(6)
 			e.Vars = append(e.Vars,
 				"topic="+topic,
 				"KT_BROKERS="+testBrokerAddr,
-				"now="+time.Now().Format(time.RFC3339),
+				"now="+time.Now().UTC().Format(time.RFC3339),
 			)
 			e.Defer(func() {
 				if err := deleteTopic(topic); err != nil {
@@ -57,6 +60,7 @@ func TestSystem(t *testing.T) {
 			})
 			return nil
 		},
+		UpdateScripts: *updateFlag,
 	})
 }
 

--- a/testdata/multipartition.txt
+++ b/testdata/multipartition.txt
@@ -1,0 +1,31 @@
+kt admin -createtopic $topic -topicdetail topic-detail.json
+
+stdin produce-stdin.json
+kt produce -topic $topic
+
+kt consume -topic $topic
+cmp stdout consume-stdout.json
+
+-- topic-detail.json --
+{"NumPartitions": 5, "ReplicationFactor": 1}
+
+-- produce-stdin.json --
+{"partition":0,"key":"k1","value":"v1","time":"2019-10-08T01:01:01Z"}
+{"partition":1,"key":"k2","value":"v2","time":"2019-10-08T01:01:02Z"}
+{"partition":0,"key":"k3","value":"v3","time":"2019-10-08T01:01:03Z"}
+{"partition":1,"key":"k4","value":"v4","time":"2019-10-08T01:01:04Z"}
+{"partition":1,"key":"k5","value":"v5","time":"2019-10-08T01:01:05Z"}
+{"partition":2,"key":"k6","value":"v6","time":"2019-10-08T01:01:06Z"}
+{"partition":3,"key":"k7","value":"v7","time":"2019-10-08T01:01:07Z"}
+{"partition":3,"key":"k8","value":"v8","time":"2019-10-08T01:01:08Z"}
+{"partition":3,"key":"k9","value":"v9","time":"2019-10-08T01:01:09Z"}
+-- consume-stdout.json --
+{"partition":0,"offset":0,"key":"k1","value":"v1","time":"2019-10-08T01:01:01Z"}
+{"partition":1,"offset":0,"key":"k2","value":"v2","time":"2019-10-08T01:01:02Z"}
+{"partition":0,"offset":1,"key":"k3","value":"v3","time":"2019-10-08T01:01:03Z"}
+{"partition":1,"offset":1,"key":"k4","value":"v4","time":"2019-10-08T01:01:04Z"}
+{"partition":1,"offset":2,"key":"k5","value":"v5","time":"2019-10-08T01:01:05Z"}
+{"partition":2,"offset":0,"key":"k6","value":"v6","time":"2019-10-08T01:01:06Z"}
+{"partition":3,"offset":0,"key":"k7","value":"v7","time":"2019-10-08T01:01:07Z"}
+{"partition":3,"offset":1,"key":"k8","value":"v8","time":"2019-10-08T01:01:08Z"}
+{"partition":3,"offset":2,"key":"k9","value":"v9","time":"2019-10-08T01:01:09Z"}

--- a/testdata/system.txt
+++ b/testdata/system.txt
@@ -11,7 +11,7 @@ cmpenvjson stdout '{"count": 1, "partition": 0, "startOffset": 0}'
 # 2
 kt consume -f -topic $topic -timeout 500ms
 stderr 'consuming from partition 0 timed out after 500ms'
-cmpenvjson stdout '{"value": "hello 1", "key": "boom", "partition": 0, "offset": 0, "timestamp": "$now"}'
+cmpenvjson stdout '{"value": "hello 1", "key": "boom", "partition": 0, "offset": 0, "time": "$now"}'
 
 # 4
 stdin 4-produce/stdin.json


### PR DESCRIPTION
print consumed messages in time order

Currently when consuming from multiple partitions, messages are
arbitrarily interleaved. Although there is no inherent ordering
between partitions, it's nice to see them in (approximate) time order,
so this PR prints messages in timestamp order as far as possible.

In `-f` (follow) mode, messages are still printed as soon as they arrive.

As a nice side-effect, this means that output across partitions
can be deterministic, opening up the way to having system-level
tests that test output across multiple partitions.

We also add the capability for `hkt produce` to set a timestamp on
produced messages.

We also change the name of the timestamp field printed by
the consumer to `time` from `timestamp` for consistency with
the `hkt produce` command.
