### PR TITLE
more cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,5 @@
-export SHELL:=/usr/bin/env bash -O extglob -c
-export GO15VENDOREXPERIMENT:=1
-export OS=$(shell uname | tr '[:upper:]' '[:lower:]')
-
-build: GOOS ?= ${OS}
-build: GOARCH ?= amd64
 build:
-	rm -f kt
-	GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags "-X main.buildTime=`date --iso-8601=s` -X main.buildVersion=`git rev-parse HEAD | cut -c-7`" .
+	go build
 
-release-linux: test
-	GOOS=linux $(MAKE) build
-	tar Jcf kt-`git describe --abbrev=0 --tags`-linux-amd64.txz kt
-
-release-darwin:
-	GOOS=darwin $(MAKE) build
-	tar Jcf kt-`git describe --abbrev=0 --tags`-darwin-amd64.txz kt
-
-release: test clean release-linux release-darwin
-
-test: clean
-	go test -v
-
-clean:
-	rm -f kt
-	rm -f kt-*.txz
-
-run: build
-	./kt
+test:
+	go test

--- a/admin.go
+++ b/admin.go
@@ -7,107 +7,48 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/user"
-	"strings"
 	"time"
 
 	"github.com/Shopify/sarama"
 )
 
 type adminCmd struct {
-	brokers    []string
-	verbose    bool
-	version    sarama.KafkaVersion
-	timeout    time.Duration
-	tlsCA      string
-	tlsCert    string
-	tlsCertKey string
-
-	createTopic  string
-	topicDetail  *sarama.TopicDetail
-	validateOnly bool
-	deleteTopic  string
-
-	admin sarama.ClusterAdmin
-}
-
-type adminArgs struct {
-	brokers    string
-	verbose    bool
-	version    sarama.KafkaVersion
-	timeout    time.Duration
-	tlsCA      string
-	tlsCert    string
-	tlsCertKey string
-
+	commonFlags
+	timeout         time.Duration
 	createTopic     string
-	topicDetailPath string
 	validateOnly    bool
 	deleteTopic     string
+	topicDetailPath string
+
+	topicDetail *sarama.TopicDetail
+	admin       sarama.ClusterAdmin
 }
 
-func (cmd *adminCmd) parseArgs(as []string) error {
-	args := cmd.parseFlags(as)
-
-	cmd.verbose = args.verbose
-	cmd.timeout = args.timeout
-	cmd.version = args.version
-
-	cmd.tlsCA = args.tlsCA
-	cmd.tlsCert = args.tlsCert
-	cmd.tlsCertKey = args.tlsCertKey
-
-	cmd.brokers = strings.Split(args.brokers, ",")
-	for i, b := range cmd.brokers {
-		if !strings.Contains(b, ":") {
-			cmd.brokers[i] = b + ":9092"
-		}
+func (cmd *adminCmd) run(args []string) error {
+	if cmd.verbose {
+		sarama.Logger = log.New(os.Stderr, "", log.LstdFlags)
 	}
+	cfg, err := cmd.saramaConfig("admin")
+	if err != nil {
+		return err
+	}
+	admin, err := sarama.NewClusterAdmin(cmd.brokers, cfg)
+	if err != nil {
+		return fmt.Errorf("cannot create cluster admin: %v", err)
+	}
+	cmd.admin = admin
 
-	cmd.validateOnly = args.validateOnly
-	cmd.createTopic = args.createTopic
-	cmd.deleteTopic = args.deleteTopic
-
-	if cmd.createTopic != "" {
-		buf, err := ioutil.ReadFile(args.topicDetailPath)
+	switch {
+	case cmd.createTopic != "":
+		buf, err := ioutil.ReadFile(cmd.topicDetailPath)
 		if err != nil {
 			return err
 		}
-
 		var detail sarama.TopicDetail
 		if err = json.Unmarshal(buf, &detail); err != nil {
 			return fmt.Errorf("cannot unmarshal topic detail : %v", err)
 		}
-		cmd.topicDetail = &detail
-	}
-	return nil
-}
-
-func (cmd *adminCmd) run(args []string) {
-	if err := cmd.run1(args); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-	}
-}
-
-func (cmd *adminCmd) run1(args []string) error {
-	var err error
-
-	if err := cmd.parseArgs(args); err != nil {
-		return err
-	}
-
-	if cmd.verbose {
-		sarama.Logger = log.New(os.Stderr, "", log.LstdFlags)
-	}
-
-	if cmd.admin, err = sarama.NewClusterAdmin(cmd.brokers, cmd.saramaConfig()); err != nil {
-		return fmt.Errorf("cannot create cluster admin: %v", err)
-	}
-
-	switch {
-	case cmd.createTopic != "":
-		err := cmd.admin.CreateTopic(cmd.createTopic, cmd.topicDetail, cmd.validateOnly)
-		if err != nil {
+		if err := cmd.admin.CreateTopic(cmd.createTopic, &detail, cmd.validateOnly); err != nil {
 			return fmt.Errorf("cannot create topic: %v", err)
 		}
 	case cmd.deleteTopic != "":
@@ -121,72 +62,25 @@ func (cmd *adminCmd) run1(args []string) error {
 	return nil
 }
 
-func (cmd *adminCmd) saramaConfig() *sarama.Config {
-	var (
-		err error
-		usr *user.User
-		cfg = sarama.NewConfig()
-	)
-
-	cfg.Version = cmd.version
-	if usr, err = user.Current(); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to read current user err=%v", err)
-	}
-	cfg.ClientID = "kt-admin-" + sanitizeUsername(usr.Username)
-
-	cfg.Admin.Timeout = cmd.timeout
-
-	tlsConfig, err := setupCerts(cmd.tlsCert, cmd.tlsCA, cmd.tlsCertKey)
-	if err != nil {
-		failf("failed to setup certificates err=%v", err)
-	}
-	if tlsConfig != nil {
-		cfg.Net.TLS.Enable = true
-		cfg.Net.TLS.Config = tlsConfig
-	}
-
-	return cfg
-}
-
-func (cmd *adminCmd) parseFlags(as []string) adminArgs {
-	var args adminArgs
-	flags := flag.NewFlagSet("consume", flag.ContinueOnError)
-	flags.StringVar(&args.brokers, "brokers", "localhost:9092", "Comma separated list of brokers. Port defaults to 9092 when omitted.")
-	flags.BoolVar(&args.verbose, "verbose", false, "More verbose logging to stderr.")
-	kafkaVersionFlagVar(flags, &args.version)
-	flags.DurationVar(&args.timeout, "timeout", 3*time.Second, "Timeout for request to Kafka")
-	flags.StringVar(&args.tlsCA, "tlsca", "", "Path to the TLS certificate authority file")
-	flags.StringVar(&args.tlsCert, "tlscert", "", "Path to the TLS client certificate file")
-	flags.StringVar(&args.tlsCertKey, "tlscertkey", "", "Path to the TLS client certificate key file")
-
-	flags.StringVar(&args.createTopic, "createtopic", "", "Name of the topic that should be created.")
-	flags.StringVar(&args.topicDetailPath, "topicdetail", "", "Path to JSON encoded topic detail. cf sarama.TopicDetail")
-	flags.BoolVar(&args.validateOnly, "validateonly", false, "Flag to indicate whether operation should only validate input (supported for createtopic).")
-
-	flags.StringVar(&args.deleteTopic, "deletetopic", "", "Name of the topic that should be deleted.")
-
+func (cmd *adminCmd) addFlags(flags *flag.FlagSet) {
+	cmd.commonFlags.addFlags(flags)
+	flags.DurationVar(&cmd.timeout, "timeout", 3*time.Second, "Timeout for request to Kafka")
+	flags.StringVar(&cmd.createTopic, "createtopic", "", "Name of the topic that should be created.")
+	flags.StringVar(&cmd.topicDetailPath, "topicdetail", "", "Path to JSON encoded topic detail. cf sarama.TopicDetail")
+	flags.BoolVar(&cmd.validateOnly, "validateonly", false, "Flag to indicate whether operation should only validate input (supported for createtopic).")
+	flags.StringVar(&cmd.deleteTopic, "deletetopic", "", "Name of the topic that should be deleted.")
 	flags.Usage = func() {
 		fmt.Fprintln(os.Stderr, "Usage of admin:")
 		flags.PrintDefaults()
 		fmt.Fprintln(os.Stderr, adminDocString)
 	}
+}
 
-	err := flags.Parse(as)
-	if err != nil && strings.Contains(err.Error(), "flag: help requested") {
-		os.Exit(0)
-	} else if err != nil {
-		os.Exit(2)
-	}
-
-	if err := setFlagsFromEnv(flags, map[string]string{
+func (cmd *adminCmd) environFlags() map[string]string {
+	return map[string]string{
 		"timeout": "KT_ADMIN_TIMEOUT",
 		"brokers": "KT_BROKERS",
-	}); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(2)
 	}
-
-	return args
 }
 
 var adminDocString = `

--- a/consume_test.go
+++ b/consume_test.go
@@ -786,10 +786,11 @@ func TestConsumeParseArgsUsesEnvVar(t *testing.T) {
 	c.Setenv("KT_TOPIC", "test-topic")
 	c.Setenv("KT_BROKERS", "hans:2000")
 
-	var target consumeCmd
-	target.parseArgs(nil)
-	c.Assert(target.topic, qt.Equals, "test-topic")
-	c.Assert(target.brokers, qt.DeepEquals, []string{"hans:2000"})
+	cmd0, _, err := parseCmd("hkt", "consume")
+	c.Assert(err, qt.Equals, nil)
+	cmd := cmd0.(*consumeCmd)
+	c.Assert(cmd.topic, qt.Equals, "test-topic")
+	c.Assert(cmd.brokers, qt.DeepEquals, []string{"hans:2000"})
 }
 
 // brokers default to localhost:9092
@@ -799,11 +800,11 @@ func TestConsumeParseArgsDefault(t *testing.T) {
 
 	c.Setenv("KT_TOPIC", "")
 	c.Setenv("KT_BROKERS", "")
-
-	var target consumeCmd
-	target.parseArgs([]string{"-topic", "test-topic"})
-	c.Assert(target.topic, qt.Equals, "test-topic")
-	c.Assert(target.brokers, qt.DeepEquals, []string{"localhost:9092"})
+	cmd0, _, err := parseCmd("hkt", "consume", "-topic", "test-topic")
+	c.Assert(err, qt.Equals, nil)
+	cmd := cmd0.(*consumeCmd)
+	c.Assert(cmd.topic, qt.Equals, "test-topic")
+	c.Assert(cmd.brokers, qt.DeepEquals, []string{"localhost:9092"})
 }
 
 func TestConsumeParseArgsFlagsOverrideEnv(t *testing.T) {
@@ -814,10 +815,11 @@ func TestConsumeParseArgsFlagsOverrideEnv(t *testing.T) {
 	c.Setenv("KT_TOPIC", "BLUBB")
 	c.Setenv("KT_BROKERS", "BLABB")
 
-	var target consumeCmd
-	target.parseArgs([]string{"-topic", "test-topic", "-brokers", "hans:2000"})
-	c.Assert(target.topic, qt.Equals, "test-topic")
-	c.Assert(target.brokers, qt.DeepEquals, []string{"hans:2000"})
+	cmd0, _, err := parseCmd("hkt", "consume", "-topic", "test-topic", "-brokers", "hans:2000")
+	c.Assert(err, qt.Equals, nil)
+	cmd := cmd0.(*consumeCmd)
+	c.Assert(cmd.topic, qt.Equals, "test-topic")
+	c.Assert(cmd.brokers, qt.DeepEquals, []string{"hans:2000"})
 }
 
 func T(s string) time.Time {

--- a/system_test.go
+++ b/system_test.go
@@ -19,11 +19,7 @@ var updateFlag = flag.Bool("update", false, "update testscript scripts to corres
 // function so that it can be invoked by the testscript tests.
 func TestMain(m *testing.M) {
 	os.Exit(testscript.RunMain(m, map[string]func() int{
-		"kt": func() int {
-			main()
-			// TODO make main return exit code.
-			return 0
-		},
+		"kt": main1,
 	}))
 }
 

--- a/testdata/multipartition.txt
+++ b/testdata/multipartition.txt
@@ -4,7 +4,10 @@ stdin produce-stdin.json
 kt produce -topic $topic
 
 kt consume -topic $topic
-cmp stdout consume-stdout.json
+cmp stdout consume-1-stdout.json
+
+kt consume -offsets 3=1:newest-1 -topic $topic
+cmp stdout consume-2-stdout.json
 
 -- topic-detail.json --
 {"NumPartitions": 5, "ReplicationFactor": 1}
@@ -19,7 +22,8 @@ cmp stdout consume-stdout.json
 {"partition":3,"key":"k7","value":"v7","time":"2019-10-08T01:01:07Z"}
 {"partition":3,"key":"k8","value":"v8","time":"2019-10-08T01:01:08Z"}
 {"partition":3,"key":"k9","value":"v9","time":"2019-10-08T01:01:09Z"}
--- consume-stdout.json --
+{"partition":3,"key":"k10","value":"v10","time":"2019-10-08T01:01:10Z"}
+-- consume-1-stdout.json --
 {"partition":0,"offset":0,"key":"k1","value":"v1","time":"2019-10-08T01:01:01Z"}
 {"partition":1,"offset":0,"key":"k2","value":"v2","time":"2019-10-08T01:01:02Z"}
 {"partition":0,"offset":1,"key":"k3","value":"v3","time":"2019-10-08T01:01:03Z"}
@@ -27,5 +31,9 @@ cmp stdout consume-stdout.json
 {"partition":1,"offset":2,"key":"k5","value":"v5","time":"2019-10-08T01:01:05Z"}
 {"partition":2,"offset":0,"key":"k6","value":"v6","time":"2019-10-08T01:01:06Z"}
 {"partition":3,"offset":0,"key":"k7","value":"v7","time":"2019-10-08T01:01:07Z"}
+{"partition":3,"offset":1,"key":"k8","value":"v8","time":"2019-10-08T01:01:08Z"}
+{"partition":3,"offset":2,"key":"k9","value":"v9","time":"2019-10-08T01:01:09Z"}
+{"partition":3,"offset":3,"key":"k10","value":"v10","time":"2019-10-08T01:01:10Z"}
+-- consume-2-stdout.json --
 {"partition":3,"offset":1,"key":"k8","value":"v8","time":"2019-10-08T01:01:08Z"}
 {"partition":3,"offset":2,"key":"k9","value":"v9","time":"2019-10-08T01:01:09Z"}

--- a/topic_test.go
+++ b/topic_test.go
@@ -12,9 +12,10 @@ func TestTopicParseArgsUsesEnvVar(t *testing.T) {
 
 	c.Setenv("KT_BROKERS", "hans:2000")
 
-	var target topicCmd
-	target.parseArgs(nil)
-	c.Assert(target.brokers, qt.DeepEquals, []string{"hans:2000"})
+	cmd0, _, err := parseCmd("hkt", "topic")
+	c.Assert(err, qt.Equals, nil)
+	cmd := cmd0.(*topicCmd)
+	c.Assert(cmd.brokers, qt.DeepEquals, []string{"hans:2000"})
 }
 
 // brokers default to localhost:9092
@@ -24,9 +25,10 @@ func TestTopicParseArgsDefault(t *testing.T) {
 
 	c.Setenv("KT_BROKERS", "")
 
-	var target topicCmd
-	target.parseArgs(nil)
-	c.Assert(target.brokers, qt.DeepEquals, []string{"localhost:9092"})
+	cmd0, _, err := parseCmd("hkt", "topic")
+	c.Assert(err, qt.Equals, nil)
+	cmd := cmd0.(*topicCmd)
+	c.Assert(cmd.brokers, qt.DeepEquals, []string{"localhost:9092"})
 }
 
 func TestTopicParseArgsFlagsOverrideEnv(t *testing.T) {
@@ -36,7 +38,8 @@ func TestTopicParseArgsFlagsOverrideEnv(t *testing.T) {
 	// command line arg wins
 	c.Setenv("KT_BROKERS", "BLABB")
 
-	var target topicCmd
-	target.parseArgs([]string{"-brokers", "hans:2000"})
-	c.Assert(target.brokers, qt.DeepEquals, []string{"hans:2000"})
+	cmd0, _, err := parseCmd("hkt", "topic", "-brokers", "hans:2000")
+	c.Assert(err, qt.Equals, nil)
+	cmd := cmd0.(*topicCmd)
+	c.Assert(cmd.brokers, qt.DeepEquals, []string{"hans:2000"})
 }


### PR DESCRIPTION
This started by getting the hkt subcommands to avoid calling os.Exit,
but ended up cleanup up a bunch of duplicated code and other stuff.

- remove the version/build time info - we've got `go version` for that.
- factor out logic for flags common to all commands into a single place.
- use the more conventional `: %v` suffix for error messages rather than ` err=%s`.
- remove the redundant Args types, parsing flags directly into the command types instead.