### PR TITLE
change consume CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Some reasons why you might be interested:
 * Modify consumer group offsets (e.g., resetting or manually setting offsets per topic and per partition).
 * JSON output for easy consumption with tools like [kp](https://github.com/echojc/kp) or [jq](https://stedolan.github.io/jq/).
 * JSON input to facilitate automation via tools like [jsonify](https://github.com/fgeller/jsonify).
-* Configure brokers and topic via environment variables `KT_BROKERS` and `KT_TOPIC` for a shell session.
+* Configure brokers with the `KT_BROKERS` environment variable.
 * Fast start up time.
 * No buffering of output.
 * Binary keys and payloads can be passed and presented in base64 or hex encoding.

--- a/consume_test.go
+++ b/consume_test.go
@@ -783,13 +783,11 @@ func TestConsumeParseArgsUsesEnvVar(t *testing.T) {
 	c := qt.New(t)
 	defer c.Done()
 
-	c.Setenv("KT_TOPIC", "test-topic")
 	c.Setenv("KT_BROKERS", "hans:2000")
 
 	cmd0, _, err := parseCmd("hkt", "consume")
 	c.Assert(err, qt.Equals, nil)
 	cmd := cmd0.(*consumeCmd)
-	c.Assert(cmd.topic, qt.Equals, "test-topic")
 	c.Assert(cmd.brokers, qt.DeepEquals, []string{"hans:2000"})
 }
 
@@ -798,12 +796,10 @@ func TestConsumeParseArgsDefault(t *testing.T) {
 	c := qt.New(t)
 	defer c.Done()
 
-	c.Setenv("KT_TOPIC", "")
 	c.Setenv("KT_BROKERS", "")
-	cmd0, _, err := parseCmd("hkt", "consume", "-topic", "test-topic")
+	cmd0, _, err := parseCmd("hkt", "consume")
 	c.Assert(err, qt.Equals, nil)
 	cmd := cmd0.(*consumeCmd)
-	c.Assert(cmd.topic, qt.Equals, "test-topic")
 	c.Assert(cmd.brokers, qt.DeepEquals, []string{"localhost:9092"})
 }
 
@@ -812,13 +808,11 @@ func TestConsumeParseArgsFlagsOverrideEnv(t *testing.T) {
 	defer c.Done()
 
 	// command line arg wins
-	c.Setenv("KT_TOPIC", "BLUBB")
 	c.Setenv("KT_BROKERS", "BLABB")
 
-	cmd0, _, err := parseCmd("hkt", "consume", "-topic", "test-topic", "-brokers", "hans:2000")
+	cmd0, _, err := parseCmd("hkt", "consume", "-brokers", "hans:2000")
 	c.Assert(err, qt.Equals, nil)
 	cmd := cmd0.(*consumeCmd)
-	c.Assert(cmd.topic, qt.Equals, "test-topic")
 	c.Assert(cmd.brokers, qt.DeepEquals, []string{"hans:2000"})
 }
 

--- a/group.go
+++ b/group.go
@@ -71,7 +71,6 @@ func (cmd *groupCmd) addFlags(flags *flag.FlagSet) {
 
 func (cmd *groupCmd) environFlags() map[string]string {
 	return map[string]string{
-		"topic":   "KT_TOPIC",
 		"brokers": "KT_BROKERS",
 	}
 }
@@ -390,8 +389,8 @@ func (cmd *groupCmd) connect(broker *sarama.Broker) error {
 }
 
 var groupDocString = `
-The values for -topic and -brokers can also be set via environment variables KT_TOPIC and KT_BROKERS respectively.
-The values supplied on the command line win over environment variable values.
+The value for -brokers can also be set with the environment variable KT_BROKERS.
+The value supplied on the command line takes precedence over the environment variable.
 
 The group command can be used to list groups, their offsets and lag and to reset a group's offset.
 

--- a/produce.go
+++ b/produce.go
@@ -79,7 +79,6 @@ func (cmd *produceCmd) addFlags(flags *flag.FlagSet) {
 
 func (cmd *produceCmd) environFlags() map[string]string {
 	return map[string]string{
-		"topic":   "KT_TOPIC",
 		"brokers": "KT_BROKERS",
 	}
 }
@@ -261,8 +260,8 @@ func (p producerPartitioner) MessageRequiresConsistency(m *sarama.ProducerMessag
 }
 
 var produceDocString = `
-The values for -topic and -brokers can also be set via environment variables KT_TOPIC and KT_BROKERS respectively.
-The values supplied on the command line win over environment variable values.
+The value for -brokers can also be set with the environment variable KT_BROKERS.
+The value supplied on the command line takes precedence over the environment variable.
 
 Input is read from stdin and separated by newlines.
 

--- a/produce_test.go
+++ b/produce_test.go
@@ -13,14 +13,12 @@ func TestProduceParseArgsUsesEnvVar(t *testing.T) {
 	c := qt.New(t)
 	defer c.Done()
 
-	c.Setenv("KT_TOPIC", "test-topic")
 	c.Setenv("KT_BROKERS", "hans:2000")
 
 	cmd0, _, err := parseCmd("hkt", "produce")
 	c.Assert(err, qt.Equals, nil)
 	cmd := cmd0.(*produceCmd)
 
-	c.Assert(cmd.topic, qt.Equals, "test-topic")
 	c.Assert(cmd.brokers, qt.DeepEquals, []string{"hans:2000"})
 }
 
@@ -29,13 +27,11 @@ func TestProduceParseArgsDefault(t *testing.T) {
 	c := qt.New(t)
 	defer c.Done()
 
-	c.Setenv("KT_TOPIC", "")
 	c.Setenv("KT_BROKERS", "")
 
-	cmd0, _, err := parseCmd("hkt", "produce", "-topic", "test-topic")
+	cmd0, _, err := parseCmd("hkt", "produce")
 	c.Assert(err, qt.Equals, nil)
 	cmd := cmd0.(*produceCmd)
-	c.Assert(cmd.topic, qt.Equals, "test-topic")
 	c.Assert(cmd.brokers, qt.DeepEquals, []string{"localhost:9092"})
 }
 
@@ -44,13 +40,11 @@ func TestProduceParseArgsFlagsOverrideEnv(t *testing.T) {
 	defer c.Done()
 
 	// command line arg wins
-	c.Setenv("KT_TOPIC", "BLUBB")
 	c.Setenv("KT_BROKERS", "BLABB")
 
-	cmd0, _, err := parseCmd("hkt", "produce", "-topic", "test-topic", "-brokers", "hans:2000")
+	cmd0, _, err := parseCmd("hkt", "produce", "-brokers", "hans:2000")
 	c.Assert(err, qt.Equals, nil)
 	cmd := cmd0.(*produceCmd)
-	c.Assert(cmd.topic, qt.Equals, "test-topic")
 	c.Assert(cmd.brokers, qt.DeepEquals, []string{"hans:2000"})
 }
 

--- a/testdata/consume-with-key.txt
+++ b/testdata/consume-with-key.txt
@@ -8,16 +8,16 @@ kt produce -valuecodec string -partitioner std -topic $topic
 
 # consuming with just the default (sarama) partitioner will only
 # get messages from the partition chosen by that.
-kt consume -valuecodec string -key k1 -topic $topic
+kt consume -valuecodec string -key k1 $topic
 cmp stdout consume-1-stdout.json
 
 # adding another partitioner will pull in that partition too
-kt consume -valuecodec string -key k1 -partitioners sarama,std -topic $topic
+kt consume -valuecodec string -key k1 -partitioners sarama,std $topic
 cmp stdout consume-2-stdout.json
 
 # specifying "all" will pull in the message that was sent to the
 # manually chosen partition too
-kt consume -valuecodec string -key k1 -partitioners all -topic $topic
+kt consume -valuecodec string -key k1 -partitioners all $topic
 cmp stdout consume-3-stdout.json
 
 -- topic-detail.json --

--- a/testdata/jsonmessages-consume-error.txt
+++ b/testdata/jsonmessages-consume-error.txt
@@ -3,7 +3,7 @@ kt admin -createtopic $topic -topicdetail topic-detail.json
 stdin produce-stdin.json
 kt produce -valuecodec string -topic $topic
 
-kt consume -topic $topic
+kt consume $topic
 cmp stdout consume-stdout.json
 cmp stderr consume-stderr
 

--- a/testdata/jsonmessages.txt
+++ b/testdata/jsonmessages.txt
@@ -3,7 +3,7 @@ kt admin -createtopic $topic -topicdetail topic-detail.json
 stdin produce-stdin.json
 kt produce -topic $topic
 
-kt consume -topic $topic
+kt consume $topic
 cmp stdout consume-stdout.json
 
 -- topic-detail.json --

--- a/testdata/multipartition.txt
+++ b/testdata/multipartition.txt
@@ -3,10 +3,10 @@ kt admin -createtopic $topic -topicdetail topic-detail.json
 stdin produce-stdin.json
 kt produce -valuecodec string -topic $topic
 
-kt consume -valuecodec string -topic $topic
+kt consume -valuecodec string $topic
 cmp stdout consume-1-stdout.json
 
-kt consume -valuecodec string -offsets 3=1:newest-1 -topic $topic
+kt consume -valuecodec string $topic 3=1:newest-1
 cmp stdout consume-2-stdout.json
 
 -- topic-detail.json --

--- a/testdata/system.txt
+++ b/testdata/system.txt
@@ -9,7 +9,7 @@ kt produce -valuecodec string -topic $topic
 ! stdout .
 
 # 2
-kt consume -valuecodec string -f -topic $topic -timeout 500ms
+kt consume -valuecodec string -f -timeout 500ms $topic
 stderr 'consuming from partition 0 timed out after 500ms'
 cmpenvjson stdout '{"value": "hello 1", "key": "boom", "partition": 0, "offset": 0, "time": "$now"}'
 


### PR DESCRIPTION
Currently the consume subcommand usage uses flags
to specify both the topic and the offsets to be consumed.

Given that both are very commonly specified, using
flags seems overly verbose, so we change to using
positional arguments instead.

Instead of the current:

	hkt consume -topic my-topic -offsets all=newest-30m:

the new usage is:

	hkt consume my-topic all=newest-30m:

The KT_TOPIC environment variable is no longer recognised by
the hkt command.