### PR TITLE
JSON values for messages

### DIFF
--- a/testdata/jsonmessages-consume-error.txt
+++ b/testdata/jsonmessages-consume-error.txt
@@ -1,0 +1,18 @@
+kt admin -createtopic $topic -topicdetail topic-detail.json
+
+stdin produce-stdin.json
+kt produce -valuecodec string -topic $topic
+
+kt consume -topic $topic
+cmp stdout consume-stdout.json
+cmp stderr consume-stderr
+
+-- topic-detail.json --
+{"NumPartitions": 1, "ReplicationFactor": 1}
+-- produce-stdin.json --
+{"key":"k1","value":"]","time":"2019-10-08T01:01:01Z"}
+{"key":"k2","value":"1234","time":"2019-10-08T01:01:02Z"}
+-- consume-stdout.json --
+{"partition":0,"offset":1,"key":"k2","value":1234,"time":"2019-10-08T01:01:02Z"}
+-- consume-stderr --
+hkt: warning: invalid message in partition 0, offset 0: invalid value: invalid JSON value "]": invalid character ']' looking for beginning of value

--- a/testdata/jsonmessages.txt
+++ b/testdata/jsonmessages.txt
@@ -1,0 +1,16 @@
+kt admin -createtopic $topic -topicdetail topic-detail.json
+
+stdin produce-stdin.json
+kt produce -topic $topic
+
+kt consume -topic $topic
+cmp stdout consume-stdout.json
+
+-- topic-detail.json --
+{"NumPartitions": 1, "ReplicationFactor": 1}
+-- produce-stdin.json --
+{"key":"k1","value":{"a":"b"},"time":"2019-10-08T01:01:01Z"}
+{"key":"k2","value":1234,"time":"2019-10-08T01:01:02Z"}
+-- consume-stdout.json --
+{"partition":0,"offset":0,"key":"k1","value":{"a":"b"},"time":"2019-10-08T01:01:01Z"}
+{"partition":0,"offset":1,"key":"k2","value":1234,"time":"2019-10-08T01:01:02Z"}

--- a/testdata/multipartition.txt
+++ b/testdata/multipartition.txt
@@ -1,12 +1,12 @@
 kt admin -createtopic $topic -topicdetail topic-detail.json
 
 stdin produce-stdin.json
-kt produce -topic $topic
+kt produce -valuecodec string -topic $topic
 
-kt consume -topic $topic
+kt consume -valuecodec string -topic $topic
 cmp stdout consume-1-stdout.json
 
-kt consume -offsets 3=1:newest-1 -topic $topic
+kt consume -valuecodec string -offsets 3=1:newest-1 -topic $topic
 cmp stdout consume-2-stdout.json
 
 -- topic-detail.json --

--- a/testdata/system.txt
+++ b/testdata/system.txt
@@ -4,18 +4,18 @@ kt admin -createtopic $topic -topicdetail 0-admin/topic.json
 
 # 1
 stdin 1-produce/stdin.json
-kt produce -topic $topic
+kt produce -valuecodec string -topic $topic
 ! stderr .
 cmpenvjson stdout '{"count": 1, "partition": 0, "startOffset": 0}'
 
 # 2
-kt consume -f -topic $topic -timeout 500ms
+kt consume -valuecodec string -f -topic $topic -timeout 500ms
 stderr 'consuming from partition 0 timed out after 500ms'
 cmpenvjson stdout '{"value": "hello 1", "key": "boom", "partition": 0, "offset": 0, "time": "$now"}'
 
 # 4
 stdin 4-produce/stdin.json
-kt produce -topic $topic
+kt produce -valuecodec string -topic $topic
 ! stderr .
 cmpenvjson stdout '{"count": 1, "partition": 0, "startOffset": 1}'
 


### PR DESCRIPTION
We add a "json" type for consumed message values, causing messages
to be priunted as the actual JSON rather than quoting it.
The `produce` command also gets support for this.

This is now the default encoding type for message values.

I found myself unable to remember the flag name (quick! does `consume`
take `-encodevalue` or `-decodevalue`?), so I've changed the
flag to `-valuecodec` and `-keycodec`, common between
`hkt consume` and `hkt produce`.