### PR TITLE
consume: show information about consumed partitions in verbose mode

### DIFF
--- a/common.go
+++ b/common.go
@@ -278,8 +278,7 @@ func encoderForType(typ string) (func([]byte) (json.RawMessage, error), error) {
 	switch typ {
 	case "json":
 		return func(data []byte) (json.RawMessage, error) {
-			var j json.RawMessage
-			if err := json.Unmarshal(data, &j); err != nil {
+			if err := json.Unmarshal(data, new(json.RawMessage)); err != nil {
 				return nil, fmt.Errorf("invalid JSON value %q: %v", data, err)
 			}
 			return json.RawMessage(data), nil

--- a/consume.go
+++ b/consume.go
@@ -128,10 +128,18 @@ func (cmd *consumeCmd) run(args []string) error {
 		if err != nil {
 			return fmt.Errorf("invalid -key argument %q: %v", cmd.keyStr, err)
 		}
-		cmd.allPartitions, err = partitioners.partitionsForKey(cmd.key, cmd.allPartitions)
+		keyPartitions, err := partitioners.partitionsForKey(cmd.key, cmd.allPartitions)
 		if err != nil {
 			return fmt.Errorf("cannot determine partitions for key: %v", err)
 		}
+		if verbose {
+			if len(keyPartitions) == len(cmd.allPartitions) {
+				fmt.Fprintf(os.Stderr, "consuming all partitions\n")
+			} else {
+				fmt.Fprintf(os.Stderr, "consuming partitions %v from %v", keyPartitions, cmd.allPartitions)
+			}
+		}
+		cmd.allPartitions = keyPartitions
 	}
 	resolvedOffsets, limits, err := cmd.resolveOffsets(context.TODO(), offsets)
 	if err != nil {


### PR DESCRIPTION
Also commit a small change left over from previous PR.
