### PR TITLE
check error from GetAvailableOffsets

### DIFF
--- a/offsetquery.go
+++ b/offsetquery.go
@@ -170,6 +170,9 @@ func (r *offsetQueryer) getOffsets(ctx context.Context, q map[int32]map[offsetRe
 	for i := 0; i < nqueries; i++ {
 		select {
 		case result := <-resultc:
+			if result.err != nil {
+				return fmt.Errorf("cannot get available offsets: %v", result.err)
+			}
 			ps, ok := result.resp.Blocks[r.topic]
 			if !ok {
 				return fmt.Errorf("topic %q not found in offsets response", r.topic)


### PR DESCRIPTION
This fixes a panic case.

Unfortunately it's hard to write a test case for this, as it relies on having a Kafka broker that exists but returns unreachable addresses for the peer brokers, so we'll just leave the path untested.
