### PR TITLE
Add -value-avro-schema-id to produce command

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,15 @@ Not only `TopicNameStrategy` is supported but `TopicRecordNameStrategy` is suppo
 a schema using `-value-avro-record-name`. This can be used in conjunction with `-value-avro-schema` or get
 latest version of the schema from the Schema Registry without providing any parameter.
 
+If the globally unique schema identifier is already known, it can be used instead:
+
+```sh
+$ echo '{"value": {"FirstName": "Cristina"}, "key": "id-44"}' | hkt produce -topic actors -registry http://localhost:8081 -value-avro-schema-id 100
+```
+
+Produces the record using schema whose identifier is `100`.
+
+
 </details>
 
 

--- a/produce.go
+++ b/produce.go
@@ -97,6 +97,17 @@ func (cmd *produceCmd) run(args []string) error {
 	cmd.partitioner = partitioner
 	var err error
 
+	if cmd.avroSchemaID != 0 {
+		// Override -valuecodec flag
+		cmd.valueCodecType = "avro"
+		if cmd.avscFile != "" {
+			return fmt.Errorf("cannot use -value-avro-schema with -value-avro-schema-id")
+		}
+		if cmd.avroRecordName != "" {
+			return fmt.Errorf("cannot use -value-avro-record-name with -value-avro-schema-id")
+		}
+	}
+
 	if cmd.avscFile != "" {
 		// Override -valuecodec flag
 		cmd.valueCodecType = "avro"
@@ -363,4 +374,10 @@ Running the following command:
    $ echo '{"key": "id-44", "value": {"Band": "cloud nothings"}}' | hkt produce -topic topic-3 -registry http://localhost:8081 -value-avro-schema band.avsc
 
 In order to know the subject, "-value-avro-record-name" can be also used.
+
+3. Use the globally unique schema identifier
+
+It uses the schema identifier defined in "-value-avro-schema-id". (Warning: It does not perform any check against the registry)
+
+   $ echo '{"key": "id-45", "value": {"Field": 2}}' | hkt produce -topic topic-1 -registry http://localhost:8081 -value-avro-schema-id 109
 `, ENV_BROKERS, ENV_REGISTRY)

--- a/produce.go
+++ b/produce.go
@@ -326,7 +326,7 @@ AVRO
 
 It can produce messages using Avro format provided -registry flag and -valuecodec avro.
 
- In order to know which schema to use, there are several ways:
+In order to know which schema to use, there are several ways:
 
 1. Kafka Schema Registry TopicNameStrategy
 

--- a/testdata/avromessages-with-id.txt
+++ b/testdata/avromessages-with-id.txt
@@ -1,0 +1,21 @@
+# Schemas are registered in system_test.go
+kt admin -createtopic $topic -topicdetail topic-detail.json
+
+stdin produce-schema-1-stdin.json
+kt produce -topic $topic -value-avro-schema-id $schemaID
+
+stdin produce-schema-2-stdin.json
+kt produce -topic $topic -value-avro-schema-id $recordSchemaID
+
+kt consume -valuecodec avro $topic
+cmp stdout consume-stdout.json
+
+-- topic-detail.json --
+{"NumPartitions": 1, "ReplicationFactor": 1}
+-- produce-schema-1-stdin.json --
+{"key":"k1","value":{"Foo":1},"time":"2021-11-16T01:01:01Z"}
+-- produce-schema-2-stdin.json --
+{"key":"k2","value":{"Bar":2.122121},"time":"2021-11-17T01:01:02Z"}
+-- consume-stdout.json --
+{"partition":0,"offset":0,"key":"k1","value":{"Foo":1},"time":"2021-11-16T01:01:01Z"}
+{"partition":0,"offset":1,"key":"k2","value":{"Bar":2.122121},"time":"2021-11-17T01:01:02Z"}


### PR DESCRIPTION
This adds support to produce Avro formatted messages
using the schema identifier directly defined in `-value-avro-schema-id` flag.

For instance:
```
echo '{"value": {"FirstName": "Cristina"}, "key": "id-44"}' | hkt produce -topic actors -registry http://localhost:8081 -value-avro-schema-id 100
```

This is a low level feature when you already know the identifier.
