### PR TITLE
Linting over code

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -77,8 +77,8 @@ func (cmd *adminCmd) addFlags(flags *flag.FlagSet) {
 
 func (cmd *adminCmd) environFlags() map[string]string {
 	return map[string]string{
-		"timeout": "KT_ADMIN_TIMEOUT",
-		"brokers": "KT_BROKERS",
+		"timeout": ENV_ADMIN_TIMEOUT,
+		"brokers": ENV_BROKERS,
 	}
 }
 

--- a/common.go
+++ b/common.go
@@ -24,7 +24,6 @@ const (
 	ENV_AUTH          = "KT_AUTH"
 	ENV_ADMIN_TIMEOUT = "KT_ADMIN_TIMEOUT"
 	ENV_BROKERS       = "KT_BROKERS"
-	ENV_TOPIC         = "KT_TOPIC"
 	ENV_REGISTRY      = "KT_REGISTRY"
 )
 

--- a/common.go
+++ b/common.go
@@ -193,41 +193,6 @@ func sanitizeUsername(u string) string {
 	return invalidClientIDCharactersRegExp.ReplaceAllString(u, "")
 }
 
-// setUpCerts takes the paths to a tls certificate, CA, and certificate key in
-// a PEM format and returns a constructed tls.Config object.
-func setUpCerts(certPath, caPath, keyPath string) (*tls.Config, error) {
-	if certPath == "" && caPath == "" && keyPath == "" {
-		return nil, nil
-	}
-
-	if certPath == "" || caPath == "" || keyPath == "" {
-		return nil, fmt.Errorf("certificate, CA and key path are required - got cert=%#v ca=%#v key=%#v", certPath, caPath, keyPath)
-	}
-
-	caString, err := ioutil.ReadFile(caPath)
-	if err != nil {
-		return nil, err
-	}
-
-	caPool := x509.NewCertPool()
-	ok := caPool.AppendCertsFromPEM(caString)
-	if !ok {
-		return nil, fmt.Errorf("unable to add cert at %s to certificate pool", caPath)
-	}
-
-	clientCert, err := tls.LoadX509KeyPair(certPath, keyPath)
-	if err != nil {
-		return nil, err
-	}
-
-	bundle := &tls.Config{
-		RootCAs:      caPool,
-		Certificates: []tls.Certificate{clientCert},
-	}
-	bundle.BuildNameToCertificate()
-	return bundle, nil
-}
-
 // setFlagsFromEnv sets unset flags in fs from environment
 // variables as specified by the flags map, which maps
 // from flag name to the environment variable for that name.

--- a/common.go
+++ b/common.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 
 	"github.com/Shopify/sarama"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 const (
@@ -150,7 +150,7 @@ type printer struct {
 
 func newPrinter(pretty bool) *printer {
 	marshal := json.Marshal
-	if pretty && terminal.IsTerminal(1) {
+	if pretty && term.IsTerminal(1) {
 		marshal = func(i interface{}) ([]byte, error) { return json.MarshalIndent(i, "", "  ") }
 	}
 	return &printer{

--- a/consume_test.go
+++ b/consume_test.go
@@ -799,7 +799,6 @@ func (c tConsumer) HighWaterMarks() map[string]map[int32]int64 {
 
 func TestConsumeParseArgsUsesEnvVar(t *testing.T) {
 	c := qt.New(t)
-	defer c.Done()
 
 	registry := "localhost:8084"
 	broker := "hans:2000"
@@ -817,7 +816,6 @@ func TestConsumeParseArgsUsesEnvVar(t *testing.T) {
 // brokers default to localhost:9092
 func TestConsumeParseArgsDefault(t *testing.T) {
 	c := qt.New(t)
-	defer c.Done()
 
 	c.Setenv(ENV_BROKERS, "")
 	c.Setenv(ENV_REGISTRY, "")
@@ -831,7 +829,6 @@ func TestConsumeParseArgsDefault(t *testing.T) {
 
 func TestConsumeParseArgsFlagsOverrideEnv(t *testing.T) {
 	c := qt.New(t)
-	defer c.Done()
 
 	registry := "localhost:8084"
 	broker := "hans:2000"
@@ -849,7 +846,6 @@ func TestConsumeParseArgsFlagsOverrideEnv(t *testing.T) {
 
 func TestConsumeAvroMessage(t *testing.T) {
 	c := qt.New(t)
-	defer c.Done()
 
 	type record struct {
 		A int
@@ -951,7 +947,7 @@ func newTestRegistry(c *qt.C) *testRegistry {
 		RetryStrategy: retry.Regular{},
 	})
 	c.Assert(err, qt.IsNil)
-	c.Defer(func() {
+	c.Cleanup(func() {
 		err := reg.registry.DeleteSubject(ctx, reg.sub)
 		c.Check(err, qt.IsNil)
 		if reg.srv != nil {

--- a/consume_test.go
+++ b/consume_test.go
@@ -683,13 +683,17 @@ func TestConsume(t *testing.T) {
 	target.topic = "hans"
 	target.brokerStrs = []string{"localhost:9092"}
 
-	go target.consume(map[int32]resolvedInterval{
-		1: {1, 5},
-		2: {1, 5},
-	}, map[int32]int64{
-		1: 1,
-		2: 1,
-	})
+	go func() {
+		err := target.consume(map[int32]resolvedInterval{
+			1: {1, 5},
+			2: {1, 5},
+		}, map[int32]int64{
+			1: 1,
+			2: 1,
+		})
+		c.Check(err, qt.IsNil)
+	}()
+
 	defer close(closer)
 
 	var actual []tConsumePartition
@@ -984,7 +988,7 @@ func (reg *testRegistry) fakeServerHandler(w http.ResponseWriter, r *http.Reques
 
 	w.Header().Set("Content-Type", "application/vnd.schemaregistry.v1+json")
 	w.WriteHeader(http.StatusOK)
-	w.Write(body)
+	_, _ = w.Write(body)
 }
 
 // createAvroMessage is a helper to create Avro message.

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,10 @@ require (
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rogpeppe/go-internal v1.8.0
-	golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa
+	golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa // indirect
 	golang.org/x/net v0.0.0-20210917221730-978cfadd31cf // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/retry.v1 v1.0.3
 )

--- a/group.go
+++ b/group.go
@@ -221,7 +221,7 @@ func (cmd *groupCmd) printGroupTopicOffset(out *printer, grp, top string, parts 
 		})
 	}
 	go func() {
-		wg.Wait()
+		_ = wg.Wait()
 		close(results)
 	}()
 	for res := range results {

--- a/produce_test.go
+++ b/produce_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestProduceParseArgsUsesEnvVar(t *testing.T) {
 	c := qt.New(t)
-	defer c.Done()
 
 	c.Setenv(ENV_BROKERS, "hans:2000")
 
@@ -26,7 +25,6 @@ func TestProduceParseArgsUsesEnvVar(t *testing.T) {
 // brokers default to localhost:9092
 func TestProduceParseArgsDefault(t *testing.T) {
 	c := qt.New(t)
-	defer c.Done()
 
 	c.Setenv(ENV_BROKERS, "")
 
@@ -38,7 +36,6 @@ func TestProduceParseArgsDefault(t *testing.T) {
 
 func TestProduceParseArgsFlagsOverrideEnv(t *testing.T) {
 	c := qt.New(t)
-	defer c.Done()
 
 	// command line arg wins
 	c.Setenv(ENV_BROKERS, "BLABB")

--- a/topic_test.go
+++ b/topic_test.go
@@ -8,7 +8,6 @@ import (
 
 func TestTopicParseArgsUsesEnvVar(t *testing.T) {
 	c := qt.New(t)
-	defer c.Done()
 
 	c.Setenv(ENV_BROKERS, "hans:2000")
 
@@ -21,7 +20,6 @@ func TestTopicParseArgsUsesEnvVar(t *testing.T) {
 // brokers default to localhost:9092
 func TestTopicParseArgsDefault(t *testing.T) {
 	c := qt.New(t)
-	defer c.Done()
 
 	c.Setenv(ENV_BROKERS, "")
 
@@ -33,7 +31,6 @@ func TestTopicParseArgsDefault(t *testing.T) {
 
 func TestTopicParseArgsFlagsOverrideEnv(t *testing.T) {
 	c := qt.New(t)
-	defer c.Done()
 
 	// command line arg wins
 	c.Setenv(ENV_BROKERS, "BLABB")


### PR DESCRIPTION
Read commit by commit but it goes over running

`golangci-lint run` several times

﻿- Adapt env variables variables
- Remove dead code
- s#golang.org/x/crypto/ssh/terminal#golang.org/x/term#g
- Make error check explicit
- Use c.Cleanup from std
